### PR TITLE
Support output of multiple errors in install command

### DIFF
--- a/pkg/config/github.go
+++ b/pkg/config/github.go
@@ -370,8 +370,6 @@ func (r *GitHubRelease) Download(ctx context.Context) error {
 		return regexp.MustCompile(expr).MatchString(asset.Name)
 	})
 
-	saved := r
-
 	r.filter(func(asset Asset) bool {
 		expr := ""
 		// TODO: need to improve: neovim case (nemvim doesn't have GOARCH)
@@ -385,10 +383,10 @@ func (r *GitHubRelease) Download(ctx context.Context) error {
 	})
 
 	if len(r.Assets) == 0 {
-		// log.Printf("[DEBUG] no assets: %#v\n", r)
-		// return nil
-		r = saved
+		log.Printf("[DEBUG] no assets: %#v\n", r)
+		return fmt.Errorf("%s not found assets", r.Name)
 	}
+
 	// TODO: avoid to panic
 	asset := r.Assets[0]
 


### PR DESCRIPTION
## WHAT

Support multiple error output when running install command

### Before

```console
$ afx i
? Please type your GITHUB_TOKEN [? for help] ****************************************
✖ fx
✔ procs
✖ cob
✖ blogsync
✖ cli
✖ kubectl-view-secret
[ERROR]: failed to get from release: failed to download: {0x1b976c0 fx []}: fx not found assets
```

### After

```console
$ afx i
? Please type your GITHUB_TOKEN [? for help] ****************************************
✖ fx
✔ procs
✖ cob
✖ blogsync
✖ cli
✖ kubectl-view-secret
[ERROR]: 4 errors occurred:
        * failed to get from release: failed to download: {0x1b976c0 fx []}: fx not found assets
        * failed to get from release: failed to download: {0x1b976c0 blogsync [{blogsync_v0.11.0_darwin_amd64.zip /Users/babarot/.afx/github.com/x-motemen/blogsync /Users/babarot/.afx/github.com/x-motemen/blogsync/blogsync_v0.11.0_darwin_amd64.zip https://github.com/x-motemen/blogsync/releases/download/v0.11.0/blogsync_v0.11.0_darwin_amd64.zip}]}: context canceled
        * failed to get from release: failed to download: {0x1b976c0 gh [{gh_0.5.2_macOS_amd64.tar.gz /Users/babarot/.afx/github.com/cli/cli /Users/babarot/.afx/github.com/cli/cli/gh_0.5.2_macOS_amd64.tar.gz https://github.com/cli/cli/releases/download/v0.5.2/gh_0.5.2_macOS_amd64.tar.gz}]}: context canceled
        * context canceled

````


## WHY

To make more easier to know why the installation failed