### PR TITLE
Add `if` section to command and plugin installation or initialization

### DIFF
--- a/docs/configuration/command.md
+++ b/docs/configuration/command.md
@@ -313,3 +313,36 @@ string | no
           echo "see github.com/tmux-plugins/tpm"
 
     ```
+
+### if
+
+Type | Required
+---|---
+string | no
+
+`if` allows you to specify the condition to load packages. If it returns true, then the command will be linked. But if it returns false, the command will not be linked.
+
+In `if` field, you can write shell scripts (currently `bash` is only supported). The exit code finally returned from that shell script is used to determine whether it links command or not.
+
+=== "Case 1"
+
+    ```yaml hl_lines="10 11" title="link commands if git is installed"
+    github:
+    - name: chmln/sd
+      description: Intuitive find & replace CLI (sed alternative)
+      owner: chmln
+      repo: sd
+      release:
+        name: sd
+        tag: 0.6.5
+      command:
+        if: |
+          type git &>/dev/null
+        snippet: |
+          replace() {
+            case "${#}" in
+              1) git grep "${1}" ;;
+              2) git grep -l "${1}" | xargs -I% sd "${1}" "${2}" % ;;
+            esac
+          }
+    ```

--- a/docs/configuration/plugin.md
+++ b/docs/configuration/plugin.md
@@ -111,3 +111,26 @@ string | no
           echo "enhancd is enabled, cd command is overrided by enhancd"
           echo "see github.com/b4b4r07/enhancd"
     ```
+
+### if
+
+Type | Required
+---|---
+string | no
+
+`if` allows you to specify the condition to load packages. If it returns true, then the plugin will be loaded. But if it returns false, the plugin will not be loaded.
+
+In `if` field, you can write shell scripts (currently `bash` is only supported). The exit code finally returned from that shell script is used to determine whether it loads plugin or not.
+
+=== "Case 1"
+
+    ```yaml hl_lines="5 6" title="if login shell is zsh, plugin will be loaded"
+    local:
+    - name: zsh
+      directory: ~/.zsh
+      plugin:
+        if: |
+          [[ $SHELL == *zsh* ]]
+        sources:
+        - '[0-9]*.zsh'
+    ```

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -211,6 +211,17 @@ func (c Command) build(pkg Package) error {
 
 // Install is
 func (c Command) Install(pkg Package) error {
+	if len(c.If) > 0 {
+		cmd := exec.CommandContext(context.Background(), "bash", "-c", c.If)
+		err := cmd.Run()
+		switch cmd.ProcessState.ExitCode() {
+		case 0:
+		default:
+			log.Printf("[ERROR] %s: command.if returns not zero, so stopped to install package", pkg.GetName())
+			return fmt.Errorf("%s: failed to run command.if: %w", pkg.GetName(), err)
+		}
+	}
+
 	if c.buildRequired() {
 		err := c.build(pkg)
 		if err != nil {
@@ -270,17 +281,6 @@ func (c Command) Init(pkg Package) error {
 		msg := fmt.Sprintf("package %s is not installed, so skip to init", pkg.GetName())
 		fmt.Printf("## %s\n", msg)
 		return errors.New(msg)
-	}
-
-	if len(c.If) > 0 {
-		cmd := exec.CommandContext(context.Background(), "bash", "-c", c.If)
-		err := cmd.Run()
-		switch cmd.ProcessState.ExitCode() {
-		case 0:
-		default:
-			log.Printf("[ERROR] %s: command.if returns not zero, so stopped to init package", pkg.GetName())
-			return err
-		}
 	}
 
 	for k, v := range c.Env {

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -212,10 +212,9 @@ func (c Command) build(pkg Package) error {
 // Install is
 func (c Command) Install(pkg Package) error {
 	if c.buildRequired() {
-		log.Printf("[DEBUG] build command block...\n")
 		err := c.build(pkg)
 		if err != nil {
-			return errors.Wrapf(err, "failed to build: %s", pkg.GetName())
+			return errors.Wrapf(err, "%s: failed to build", pkg.GetName())
 		}
 	}
 
@@ -225,8 +224,8 @@ func (c Command) Install(pkg Package) error {
 	}
 
 	if len(links) == 0 {
-		log.Printf("[ERROR] no links: %s\n", pkg.GetName())
-		return fmt.Errorf("%s: GetLlink() returns nothing", pkg.GetName())
+		log.Printf("[ERROR] %s: no links", pkg.GetName())
+		return fmt.Errorf("%s: GetLink() returns nothing", pkg.GetName())
 	}
 
 	var errs errors.Errors
@@ -234,13 +233,13 @@ func (c Command) Install(pkg Package) error {
 		// Create base dir if not exists when creating symlink
 		pdir := filepath.Dir(link.To)
 		if _, err := os.Stat(pdir); os.IsNotExist(err) {
-			log.Printf("[DEBUG] create directory to install path: %s", pdir)
+			log.Printf("[DEBUG] %s: created directory to install path", pdir)
 			os.MkdirAll(pdir, 0755)
 		}
 
 		fi, err := os.Stat(link.From)
 		if err != nil {
-			log.Printf("[ERROR] link.from %q: no such file or directory\n", link.From)
+			log.Printf("[ERROR] %s: no such file or directory\n", link.From)
 			continue
 		}
 		switch fi.Mode() {
@@ -251,11 +250,11 @@ func (c Command) Install(pkg Package) error {
 		}
 
 		if _, err := os.Lstat(link.To); err == nil {
-			log.Printf("[DEBUG] removed %s because already exists before linking", link.To)
+			log.Printf("[DEBUG] %s: removed because already exists before linking", link.To)
 			os.Remove(link.To)
 		}
 
-		log.Printf("[DEBUG] create symlink %s to %s", link.From, link.To)
+		log.Printf("[DEBUG] created symlink %s to %s", link.From, link.To)
 		if err := os.Symlink(link.From, link.To); err != nil {
 			log.Printf("[ERROR] failed to create symlink: %v", err)
 			errs.Append(err)

--- a/pkg/config/plugin.go
+++ b/pkg/config/plugin.go
@@ -33,16 +33,6 @@ func (p Plugin) Installed(pkg Package) bool {
 
 // Install is
 func (p Plugin) Install(pkg Package) error {
-	if len(p.If) > 0 {
-		cmd := exec.CommandContext(context.Background(), "bash", "-c", p.If)
-		err := cmd.Run()
-		switch cmd.ProcessState.ExitCode() {
-		case 0:
-		default:
-			log.Printf("[ERROR] %s: plugin.if returns not zero, so stopped to install package", pkg.GetName())
-			return fmt.Errorf("%s: failed to run plugin.if: %w", pkg.GetName(), err)
-		}
-	}
 	return nil
 }
 
@@ -70,6 +60,17 @@ func (p Plugin) Init(pkg Package) error {
 		msg := fmt.Sprintf("package %s is not installed, so skip to init", pkg.GetName())
 		fmt.Printf("## %s\n", msg)
 		return errors.New(msg)
+	}
+
+	if len(p.If) > 0 {
+		cmd := exec.CommandContext(context.Background(), "bash", "-c", p.If)
+		err := cmd.Run()
+		switch cmd.ProcessState.ExitCode() {
+		case 0:
+		default:
+			log.Printf("[ERROR] %s: plugin.if returns not zero, so stopped to install package", pkg.GetName())
+			return fmt.Errorf("%s: failed to run plugin.if: %w", pkg.GetName(), err)
+		}
 	}
 
 	sources := p.GetSources(pkg)


### PR DESCRIPTION
## WHAT

Add `if` field to plugin / command section like this:

```yaml
local:
- name: zsh
  directory: ~/.zsh
  plugin:
    if: |
      [[ $SHELL == *zsh* ]] ## <-- this
    sources:
    - '[0-9]*.zsh'
```

### Point 💡 

Where should we evaluate `if` field? In this patch, I dot't decide it yet.

1. `command.Install()` and `plugin.Install()`
2. `command.Init()` and `plugin.Init()`

| | `Install()` method | `Init()` method |
|---|---|---|
| **Pros** | - Stop to install itself. So surely prevent to source/link packages  | - Doesn't effect status code |
| **Cons**| - Installation is failing and returns error (returning error is bad UX even if returning non-zero code in `if` is intentional) | - Difficult to take care of command case. In plugin case, all we have to do is don't output in init step, but in command case, installation itself is already done so it's difficult to prevent to put it to PATH  |

## WHY

Some of plugins/commands don't want to be installed sometimes when it has special contexts. For example, a `local` plugin which is loading zsh files should not be initialized if login shell is bash.