### PR TITLE
Support zsh etc in `if` field

### DIFF
--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -62,6 +62,7 @@ func (m *meta) init(args []string) error {
 		"AFX_LOG":          env.Variable{},
 		"AFX_LOG_PATH":     env.Variable{},
 		"AFX_COMMAND_PATH": env.Variable{Default: filepath.Join(os.Getenv("HOME"), "bin")},
+		"AFX_SHELL":        env.Variable{Default: m.AppConfig.Shell},
 		"AFX_SUDO_PASSWORD": env.Variable{
 			Input: env.Input{
 				When:    config.HasSudoInCommandBuildSteps(m.Packages),

--- a/docs/configuration/command.md
+++ b/docs/configuration/command.md
@@ -322,7 +322,7 @@ string | no
 
 `if` allows you to specify the condition to load packages. If it returns true, then the command will be linked. But if it returns false, the command will not be linked.
 
-In `if` field, you can write shell scripts (currently `bash` is only supported). The exit code finally returned from that shell script is used to determine whether it links command or not.
+In `if` field, you can write shell scripts[^1]. The exit code finally returned from that shell script is used to determine whether it links command or not.
 
 === "Case 1"
 
@@ -346,3 +346,5 @@ In `if` field, you can write shell scripts (currently `bash` is only supported).
             esac
           }
     ```
+
+[^1]: You can configure your favorite shell to evaluate `if` field by setting `AFX_SHELL`.

--- a/docs/configuration/plugin.md
+++ b/docs/configuration/plugin.md
@@ -153,7 +153,7 @@ string | no
 
 `if` allows you to specify the condition to load packages. If it returns true, then the plugin will be loaded. But if it returns false, the plugin will not be loaded.
 
-In `if` field, you can write shell scripts (currently `bash` is only supported). The exit code finally returned from that shell script is used to determine whether it loads plugin or not.
+In `if` field, you can write shell scripts[^1]. The exit code finally returned from that shell script is used to determine whether it loads plugin or not.
 
 === "Case 1"
 
@@ -167,3 +167,5 @@ In `if` field, you can write shell scripts (currently `bash` is only supported).
         sources:
         - '[0-9]*.zsh'
     ```
+
+[^1]: You can configure your favorite shell to evaluate `if` field by setting `AFX_SHELL`.

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -286,8 +286,13 @@ func (c Command) Init(pkg Package) error {
 		return errors.New(msg)
 	}
 
+	shell := os.Getenv("AFX_SHELL")
+	if shell == "" {
+		shell = "bash"
+	}
+
 	if len(c.If) > 0 {
-		cmd := exec.CommandContext(context.Background(), "bash", "-c", c.If)
+		cmd := exec.CommandContext(context.Background(), shell, "-c", c.If)
 		err := cmd.Run()
 		switch cmd.ProcessState.ExitCode() {
 		case 0:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 
 // AppConfig represents configurations of this application itself
 type AppConfig struct {
+	Shell  string `yaml:"shell"`
 	Filter Filter `yaml:"filter"`
 }
 
@@ -38,6 +39,7 @@ type Filter struct {
 // DefaultAppConfig is default settings of AppConfig
 // Basically this will be overridden by user config if given
 var DefaultAppConfig AppConfig = AppConfig{
+	Shell: "bash",
 	Filter: Filter{
 		Command: "fzf",
 		Args:    []string{"--ansi", "--no-preview", "--height=50%", "--reverse"},
@@ -91,6 +93,7 @@ func parse(cfg Config) []Package {
 		}
 		pkgs = append(pkgs, pkg)
 	}
+
 	for _, pkg := range cfg.Gist {
 		pkgs = append(pkgs, pkg)
 	}

--- a/pkg/config/plugin.go
+++ b/pkg/config/plugin.go
@@ -63,8 +63,13 @@ func (p Plugin) Init(pkg Package) error {
 		return errors.New(msg)
 	}
 
+	shell := os.Getenv("AFX_SHELL")
+	if shell == "" {
+		shell = "bash"
+	}
+
 	if len(p.If) > 0 {
-		cmd := exec.CommandContext(context.Background(), "bash", "-c", p.If)
+		cmd := exec.CommandContext(context.Background(), shell, "-c", p.If)
 		err := cmd.Run()
 		switch cmd.ProcessState.ExitCode() {
 		case 0:


### PR DESCRIPTION
## WHAT

Support zsh etc in `if` field. I added `if` feature in #7 but it only supports bash in its evaluation. In this PR, it provides to customize it to any shells you want to use.

## WHY

To allow these kinda scripts:

```yaml
local:
- name: google-cloud-sdk
  directory: ~/Downloads/google-cloud-sdk
  plugin:
    env:
      PATH: ~/Downloads/google-cloud-sdk/bin
    sources:
    - '*.zsh.inc'
    if: |
      ## using zsh to evaluate `if`
      var="red:green:yellow:blue"
      [[ ${var[(ws,:,)3]} == "yellow" ]] ## <-- true
```