### PR TITLE
Add update-notifier feature

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -49,7 +49,6 @@ func newInstallCmd() *cobra.Command {
 			if err := c.meta.init(args); err != nil {
 				return err
 			}
-			defer c.meta.printForUpdate()
 
 			pkgs := append(c.State.Additions, c.State.Readditions...)
 			if len(pkgs) == 0 {
@@ -78,6 +77,9 @@ func newInstallCmd() *cobra.Command {
 			})
 
 			return c.run(pkgs)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			return c.meta.printForUpdate()
 		},
 	}
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -49,6 +49,7 @@ func newInstallCmd() *cobra.Command {
 			if err := c.meta.init(args); err != nil {
 				return err
 			}
+			defer c.meta.printForUpdate()
 
 			pkgs := append(c.State.Additions, c.State.Readditions...)
 			if len(pkgs) == 0 {

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -13,8 +13,11 @@ import (
 	"github.com/b4b4r07/afx/pkg/env"
 	"github.com/b4b4r07/afx/pkg/errors"
 	"github.com/b4b4r07/afx/pkg/helpers/shell"
+	"github.com/b4b4r07/afx/pkg/printers"
 	"github.com/b4b4r07/afx/pkg/state"
+	"github.com/b4b4r07/afx/pkg/update"
 	"github.com/fatih/color"
+	"github.com/mgutz/ansi"
 	"github.com/mitchellh/cli"
 )
 
@@ -25,9 +28,21 @@ type meta struct {
 	State     *state.State
 
 	UI cli.Ui
+
+	updateMessageChan chan *update.ReleaseInfo
 }
 
 func (m *meta) init(args []string) error {
+	m.updateMessageChan = make(chan *update.ReleaseInfo)
+	go func() {
+		log.Printf("[DEBUG] (goroutine): checking new updates...")
+		release, err := checkForUpdate(Version)
+		if err != nil {
+			log.Printf("[ERROR] (goroutine): cannot check for new updates: %v", err)
+		}
+		m.updateMessageChan <- release
+	}()
+
 	m.UI = &cli.ColoredUi{
 		Ui: &cli.BasicUi{
 			Reader:      os.Stdin,
@@ -101,6 +116,7 @@ func (m *meta) init(args []string) error {
 				Help:    "To fetch GitHub Releases, GitHub token is required",
 			},
 		},
+		"AFX_NO_UPDATE_NOTIFIER": env.Variable{},
 	})
 
 	log.Printf("[DEBUG] mkdir %s\n", root)
@@ -123,7 +139,24 @@ func (m *meta) init(args []string) error {
 	return nil
 }
 
-func (m *meta) Select() (config.Package, error) {
+func (m *meta) printForUpdate() {
+	switch Version {
+	case "unset":
+		return
+	}
+	log.Printf("[DEBUG] checking updates on afx repo...")
+	newRelease := <-m.updateMessageChan
+	if newRelease != nil {
+		fmt.Fprintf(os.Stdout, "\n\n%s %s -> %s\n",
+			ansi.Color("A new release of afx is available:", "yellow"),
+			ansi.Color("v"+Version, "cyan"),
+			ansi.Color(newRelease.Version, "cyan"))
+		fmt.Fprintf(os.Stdout, "%s\n\n", ansi.Color(newRelease.URL, "yellow"))
+		fmt.Fprintf(os.Stdout, "To upgrade, run: afx self-update\n")
+	}
+}
+
+func (m *meta) prompt() (config.Package, error) {
 	var stdin, stdout bytes.Buffer
 
 	cmd := shell.Shell{
@@ -175,4 +208,26 @@ func getNameInResources(resources []state.Resource) []string {
 		keys = append(keys, resource.Name)
 	}
 	return keys
+}
+
+func shouldCheckForUpdate() bool {
+	if os.Getenv("AFX_NO_UPDATE_NOTIFIER") != "" {
+		return false
+	}
+	return !isCI() && printers.IsTerminal(os.Stdout) && printers.IsTerminal(os.Stderr)
+}
+
+// based on https://github.com/watson/ci-info/blob/HEAD/index.js
+func isCI() bool {
+	return os.Getenv("CI") != "" || // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
+		os.Getenv("BUILD_NUMBER") != "" || // Jenkins, TeamCity
+		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
+}
+
+func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
+	if !shouldCheckForUpdate() {
+		return nil, nil
+	}
+	stateFilePath := filepath.Join(os.Getenv("HOME"), ".afx", "version.json")
+	return update.CheckForUpdate(stateFilePath, Repository, Version)
 }

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -139,13 +139,13 @@ func (m *meta) init(args []string) error {
 	return nil
 }
 
-func (m *meta) printForUpdate() {
+func printForUpdate(uriCh chan *update.ReleaseInfo) {
 	switch Version {
 	case "unset":
 		return
 	}
 	log.Printf("[DEBUG] checking updates on afx repo...")
-	newRelease := <-m.updateMessageChan
+	newRelease := <-uriCh
 	if newRelease != nil {
 		fmt.Fprintf(os.Stdout, "\n\n%s %s -> %s\n",
 			ansi.Color("A new release of afx is available:", "yellow"),
@@ -154,6 +154,14 @@ func (m *meta) printForUpdate() {
 		fmt.Fprintf(os.Stdout, "%s\n\n", ansi.Color(newRelease.URL, "yellow"))
 		fmt.Fprintf(os.Stdout, "To upgrade, run: afx self-update\n")
 	}
+}
+
+func (m *meta) printForUpdate() error {
+	if m.updateMessageChan == nil {
+		return errors.New("update message chan is not set")
+	}
+	printForUpdate(m.updateMessageChan)
+	return nil
 }
 
 func (m *meta) prompt() (config.Package, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var Repository string = "b4b4r07/afx"
+
 var (
 	rootLong = templates.LongDesc(`Package manager for everything`)
 )

--- a/cmd/self-update.go
+++ b/cmd/self-update.go
@@ -51,8 +51,6 @@ func newSelfUpdateCmd() *cobra.Command {
 }
 
 func (c *selfUpdateCmd) run(args []string) error {
-	const repo string = "b4b4r07/afx"
-
 	switch Version {
 	case "unset":
 		c.UI.Error("Failed to update to new version\n")
@@ -62,7 +60,7 @@ func (c *selfUpdateCmd) run(args []string) error {
 		return errors.New("failed to run self-update")
 	}
 
-	latest, found, err := selfupdate.DetectLatest(repo)
+	latest, found, err := selfupdate.DetectLatest(Repository)
 	if err != nil {
 		return errors.Wrap(err, "error occurred while detecting version")
 	}

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -47,6 +47,7 @@ func newUninstallCmd() *cobra.Command {
 			if err := c.meta.init(args); err != nil {
 				return err
 			}
+			defer c.meta.printForUpdate()
 
 			resources := c.State.Deletions
 			if len(resources) == 0 {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -47,7 +47,6 @@ func newUninstallCmd() *cobra.Command {
 			if err := c.meta.init(args); err != nil {
 				return err
 			}
-			defer c.meta.printForUpdate()
 
 			resources := c.State.Deletions
 			if len(resources) == 0 {
@@ -71,6 +70,9 @@ func newUninstallCmd() *cobra.Command {
 			}
 
 			return c.run(resources)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			return c.meta.printForUpdate()
 		},
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -49,7 +49,6 @@ func newUpdateCmd() *cobra.Command {
 			if err := c.meta.init(args); err != nil {
 				return err
 			}
-			defer c.meta.printForUpdate()
 
 			pkgs := c.State.Changes
 			if len(pkgs) == 0 {
@@ -78,6 +77,9 @@ func newUpdateCmd() *cobra.Command {
 			})
 
 			return c.run(pkgs)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			return c.meta.printForUpdate()
 		},
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -49,6 +49,7 @@ func newUpdateCmd() *cobra.Command {
 			if err := c.meta.init(args); err != nil {
 				return err
 			}
+			defer c.meta.printForUpdate()
 
 			pkgs := c.State.Changes
 			if len(pkgs) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,15 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/h2non/filetype v1.0.10
+	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcl/v2 v2.2.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mattn/go-zglob v0.0.1
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mitchellh/cli v1.1.2
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
@@ -38,6 +41,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )

--- a/pkg/printers/terminal.go
+++ b/pkg/printers/terminal.go
@@ -1,0 +1,25 @@
+package printers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"golang.org/x/term"
+)
+
+var IsTerminal = func(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || IsCygwinTerminal(f)
+}
+
+func IsCygwinTerminal(f *os.File) bool {
+	return isatty.IsCygwinTerminal(f.Fd())
+}
+
+var TerminalSize = func(w interface{}) (int, int, error) {
+	if f, isFile := w.(*os.File); isFile {
+		return term.GetSize(int(f.Fd()))
+	}
+
+	return 0, 0, fmt.Errorf("%v is not a file", w)
+}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -1,0 +1,121 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-version"
+)
+
+// refer: github.com/cli/cli/tree/<hash>/internal/update
+// hash: bf83c660a1ae486d582117e0a174f8e109b64775
+var gitDescribeSuffixRE = regexp.MustCompile(`\d+-\d+-g[a-f0-9]{8}$`)
+
+// ReleaseInfo stores information about a release
+type ReleaseInfo struct {
+	Version     string    `json:"tag_name"`
+	URL         string    `json:"html_url"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+type StateEntry struct {
+	CheckedForUpdateAt time.Time   `json:"checked_for_update_at"`
+	LatestRelease      ReleaseInfo `json:"latest_release"`
+}
+
+// CheckForUpdate checks whether this software has had a newer release on GitHub
+func CheckForUpdate(stateFilePath, repo, currentVersion string) (*ReleaseInfo, error) {
+	stateEntry, _ := getStateEntry(stateFilePath)
+	if stateEntry != nil && time.Since(stateEntry.CheckedForUpdateAt).Hours() < 24 {
+		return &stateEntry.LatestRelease, nil
+	}
+
+	releaseInfo, err := getLatestReleaseInfo(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	err = setStateEntry(stateFilePath, time.Now(), *releaseInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	if versionGreaterThan(releaseInfo.Version, currentVersion) {
+		return releaseInfo, nil
+	}
+
+	return nil, nil
+}
+
+func getLatestReleaseInfo(repo string) (*ReleaseInfo, error) {
+	var latestRelease ReleaseInfo
+
+	res, err := http.Get(fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(body, &latestRelease); err != nil {
+		return nil, err
+	}
+
+	return &latestRelease, nil
+}
+
+func getStateEntry(stateFilePath string) (*StateEntry, error) {
+	content, err := ioutil.ReadFile(stateFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var stateEntry StateEntry
+	err = json.Unmarshal(content, &stateEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stateEntry, nil
+}
+
+func setStateEntry(stateFilePath string, t time.Time, r ReleaseInfo) error {
+	data := StateEntry{CheckedForUpdateAt: t, LatestRelease: r}
+	content, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(stateFilePath), 0755)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(stateFilePath, content, 0600)
+	return err
+}
+
+func versionGreaterThan(v, w string) bool {
+	w = gitDescribeSuffixRE.ReplaceAllStringFunc(w, func(m string) string {
+		idx := strings.IndexRune(m, '-')
+		n, _ := strconv.Atoi(m[0:idx])
+		return fmt.Sprintf("%d-pre.0", n+1)
+	})
+
+	vv, ve := version.NewVersion(v)
+	vw, we := version.NewVersion(w)
+
+	return ve == nil && we == nil && vv.GreaterThan(vw)
+}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -35,6 +36,7 @@ type StateEntry struct {
 func CheckForUpdate(stateFilePath, repo, currentVersion string) (*ReleaseInfo, error) {
 	stateEntry, _ := getStateEntry(stateFilePath)
 	if stateEntry != nil && time.Since(stateEntry.CheckedForUpdateAt).Hours() < 24 {
+		log.Printf("[DEBUG] found state file of release info, so will grab it from the file.")
 		return &stateEntry.LatestRelease, nil
 	}
 
@@ -58,6 +60,7 @@ func CheckForUpdate(stateFilePath, repo, currentVersion string) (*ReleaseInfo, e
 func getLatestReleaseInfo(repo string) (*ReleaseInfo, error) {
 	var latestRelease ReleaseInfo
 
+	log.Printf("[DEBUG] call GitHub Release API to get release info")
 	res, err := http.Get(fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## WHAT

Add update-notifier (it run as background process to check if new version is released or not. If new updates are found, you can see the result on each subcommands). It's heavily inspired from cli/cli implementations.

## WHY

To make easy to update more.