### PR TITLE
Add release.asset field to github configuration

### DIFF
--- a/docs/configuration/command.md
+++ b/docs/configuration/command.md
@@ -16,7 +16,7 @@ list | yes (when using `build`)
 
     ```yaml hl_lines="7 8 9 10" title="Using sudo"
     github:
-    - name: fzy
+    - name: jhawthorn/fzy
       description: A better fuzzy finder
       owner: jhawthorn
       repo: fzy
@@ -33,7 +33,7 @@ list | yes (when using `build`)
 
     ```yaml hl_lines="7 8 9" title="Using go build"
     github:
-    - name: kubectl-trace
+    - name: iovisor/kubectl-trace
       description: Schedule bpftrace programs on your kubernetes cluster using the kubectl
       owner: iovisor
       repo: kubectl-trace
@@ -62,7 +62,7 @@ map | no
 
     ```yaml hl_lines="11 12"
     github:
-    - name: fzy
+    - name: jhawthorn/fzy
       description: A better fuzzy finder
       owner: jhawthorn
       repo: fzy
@@ -89,7 +89,7 @@ string | yes (when using `link`)
 
     ```yaml hl_lines="7 8" title="Just install from current directory"
     github:
-    - name: diff-so-fancy
+    - name: so-fancy/diff-so-fancy
       description: Good-lookin' diffs. Actually… nah… The best-lookin' diffs.
       owner: so-fancy
       repo: diff-so-fancy
@@ -104,7 +104,7 @@ string | yes (when using `link`)
 
     ```yaml hl_lines="10 11 12" title="Case of including version string etc in file name"
     github:
-    - name: jq
+    - name: stedolan/jq
       description: Command-line JSON processor
       owner: stedolan
       repo: jq
@@ -131,7 +131,7 @@ string | no
 
     ```yaml hl_lines="7 8 9" title="Simple case, with renaming by using `to` field"
     github:
-    - name: prok
+    - name: mutantcornholio/prok
       description: easy process grep with ps output
       owner: mutantcornholio
       repo: prok
@@ -149,7 +149,7 @@ string | no
 
     ```yaml hl_lines="7 8 9" title="from current working dir to external dir of afx"
     github:
-    - name: tpm
+    - name: tmux-plugins/tpm
       description: Tmux Plugin Manager
       owner: tmux-plugins
       repo: tpm
@@ -167,7 +167,7 @@ string | no
 
     ```yaml hl_lines="8 9 10 11" title="Several links"
     github:
-    - name: kubectx
+    - name: ahmetb/kubectx
       description: Switch faster between clusters and namespaces in kubectl
       owner: ahmetb
       repo: kubectx
@@ -201,7 +201,7 @@ map | no
 
     ```yaml hl_lines="12 13 14 15"
     github:
-    - name: bat
+    - name: sharkdp/bat
       description: A cat(1) clone with wings.
       owner: sharkdp
       repo: bat
@@ -231,7 +231,7 @@ map | no
 
     ```yaml hl_lines="7 8"
     github:
-    - name: colordiff
+    - name: daveewart/colordiff
       description: Primary development for colordiff
       owner: daveewart
       repo: colordiff
@@ -247,7 +247,7 @@ map | no
 
     ```yaml hl_lines="10 11 12 13 14 15"
     github:
-    - name: exa
+    - name: ogham/exa
       description: A modern version of 'ls'.
       owner: ogham
       repo: exa
@@ -270,7 +270,7 @@ map | no
 
     ```yaml hl_lines="10 11"
     github:
-    - name: bat
+    - name: sharkdp/bat
       description: A cat(1) clone with wings.
       owner: sharkdp
       repo: bat
@@ -300,7 +300,7 @@ string | no
 
     ```yaml hl_lines="10 11 12" title="Login message if tpm is installed"
     github:
-    - name: tpm
+    - name: tmux-plugins/tpm
       description: Tmux Plugin Manager
       owner: tmux-plugins
       repo: tpm
@@ -323,6 +323,8 @@ string | no
 `if` allows you to specify the condition to load packages. If it returns true, then the command will be linked. But if it returns false, the command will not be linked.
 
 In `if` field, you can write shell scripts[^1]. The exit code finally returned from that shell script is used to determine whether it links command or not.
+
+[^1]: You can configure your favorite shell to evaluate `if` field by setting `AFX_SHELL`.
 
 === "Case 1"
 
@@ -347,4 +349,14 @@ In `if` field, you can write shell scripts[^1]. The exit code finally returned f
           }
     ```
 
-[^1]: You can configure your favorite shell to evaluate `if` field by setting `AFX_SHELL`.
+!!! hint "Shell used for an evaluation of `if`"
+
+    Defaults to `bash`. But you can change it with setting `AFX_SHELL` (or `main.shell` block on afx configuration)[^2]
+
+    e.g.
+    ```
+    export AFX_SHELL=zsh
+    export AFX_SHELL=/bin/zsh
+    ```
+
+[^2]: Not yet available. Coming soon.

--- a/docs/configuration/package/github.md
+++ b/docs/configuration/package/github.md
@@ -2,12 +2,10 @@
 
 This `github` allows you to get GitHub repositories and releases. To get releases, you need to specify `release` field.
 
-## Examples
-
 === "Repository"
     ```yaml
     github:
-    - name: kubectx
+    - name: ahmetb/kubectx
       description: Switch faster between clusters and namespaces in kubectl
       owner: ahmetb
       repo: kubectx
@@ -22,7 +20,7 @@ This `github` allows you to get GitHub repositories and releases. To get release
 === "Release"
     ```yaml
     github:
-    - name: jq
+    - name: stedolan/jq
       description: Command-line JSON processor
       owner: stedolan
       repo: jq
@@ -35,17 +33,258 @@ This `github` allows you to get GitHub repositories and releases. To get release
           to: jq
     ```
 
+!!! danger "(TODO) More explanation"
+
 ## Parameters
 
-Name | Type | Required | Description
----|---|---|---
-name | string | yes | Package name (must be unique in all packages)
-description | string | | A description of a package
-owner | string | yes | GitHub owner
-repo | string | yes | GitHub repo
-with.depth | int | no | Fetch commit depth (default: 0). N>0 means shallow clone
-release.name | string | yes (in `release`) | GitHub release name
-release.tag | string | | GitHub release tag
-command | section | | See [Command](../command.md) page
-plugin | section | | See [Plugin](../plugin.md) page
-depends-on | array | Dependency list (you can write package name here)
+### name
+
+Type | Default
+---|---
+string | (required)
+
+Package name. Basically you can name it as you like. However, in GitHub package, "owner/repo" style may be suitable.
+
+### description
+
+Type | Default
+---|---
+string | `""`
+
+Package description.
+
+### owner
+
+Type | Default
+---|---
+string | (required)
+
+Repository owner.
+
+### repo
+
+Type | Default
+---|---
+string | (required)
+
+Repository name.
+
+### branch
+
+Type | Default
+---|---
+string | `master`
+
+Remote branch name.
+
+### with.depth
+
+Type | Default
+---|---
+number | `0` (all commits)
+
+Limit fetching to the specified number of commits from the tip of each remote branch history. If fetching to a shallow repository, specify 1 or more number, deepen or shorten the history to the specified number of commits.
+
+### release.name
+
+Type | Default
+---|---
+string | `""`
+
+Allows you to specify a package name managed in GitHub Release. You can find this by visiting release page of packages you want to install.
+
+### relase.tag
+
+Type | Default
+---|---
+string | `""`
+
+Allows you to specify a tag version of GitHub Release. You can find this by visiting release page of packages you want to install.
+
+### release.asset.filename
+
+Type | Default
+---|---
+string | `""`
+
+Allows you to specify a filename of GitHub Release asset you want to install. Moreover, this field in afx config file supports templating.
+
+!!! tip "(Basically) NO NEED TO SET THIS"
+
+    Basically in afx, it's no problem even if you don't specify this field when downloading a package from GitHub Release. Because afx automatically filters release assets that can work on your system (OS/Architecture, etc)even if several release assets are uploaded.
+
+    But the filename of the package uploaded to GitHub Release can be named by its author freely. So there are cases that afx cannot filter the package which is suitable on your system when too much special wording is included in a filename.
+
+    For example, the following case is,
+
+    - a filename has "steve-jobs" instead of "mac" or "darwin": `some-package-v1.0.0-steve-jobs-amd64.tar.gz`
+
+=== "Case 1"
+
+    ```yaml hl_lines="9 10" title="Specify asset filename directly"
+    github:
+    - name: direnv/direnv
+      description: Unclutter your .profile
+      owner: direnv
+      repo: direnv
+      release:
+        name: direnv
+        tag: v2.30.3
+        asset:
+          filename: direnv.darwin-amd64
+      command:
+        link:
+        - from: direnv
+    ```
+
+=== "Case 2"
+
+    ```yaml hl_lines="9 10" title="Specify asset filename with templating"
+    github:
+    - name: direnv/direnv
+      description: Unclutter your .profile
+      owner: direnv
+      repo: direnv
+      release:
+        name: direnv
+        tag: v2.30.3
+        asset:
+          filename: '{{ .Release.Name }}.{{ .OS }}-{{ .Arch }}'
+      command:
+        link:
+        - from: direnv
+    ```
+
+You can specify a filename from asset list on GitHub Release page. It allows to specify a filename directly and also to use name templating feature by using these variables provided by afx:
+
+Key | Description
+---|---
+`.Release.Name` | Same as `release.name`
+`.Release.Tag` | Same as `release.tag`
+`.OS` | [GOOS](https://go.dev/doc/install/source#environment)[^1] (e.g. `darwin` etc)
+`.Arch` | [GOARCH](https://go.dev/doc/install/source#environment)[^1] (e.g. `amd64` etc)
+
+[^1]: This can be overwritten by `replace.asset.replacements`.
+
+### release.asset.replacements
+
+Type | Default
+---|---
+map | `{}`
+
+Allows you to replace pre-defined OS/Architecture wording with yours. In afx, the templating variables of `.OS` and `.Arch` are coming from `runtime.GOOS` and `runtime.GOARCH` (The Go Programming Language). For example, your system is Mac: In this case, `GOOS` returns `darwin` string, but let's say the filename of the assets on GitHub Release you want has `mac` instead of `darwin`. In this case, you can replace it with `darwin` by defining this `replacements` map.
+
+Keys should be valid `GOOS`s or `GOARCH`s. Valid name is below (full is are on [Environment - The Go Programming Language](https://go.dev/doc/install/source#environment)). Values are the respective replacements.
+
+`GOOS` | `GOARCH`
+---|---
+darwin|amd64
+darwin|arm64
+linux|386
+linux|amd64
+linux|arm64
+windows|386
+windows|amd64
+windows|arm64
+
+=== "Case 1"
+
+    ```yaml hl_lines="9 10 11 12 13" title=""
+    github:
+    - name: sharkdp/bat
+      description: A cat(1) clone with wings.
+      owner: sharkdp
+      repo: bat
+      release:
+        name: bat
+        tag: v0.11.0
+        asset:
+          filename: '{{ .Release.Name }}-{{ .Release.Tag }}-{{ .Arch }}-{{ .OS }}.tar.gz'
+          replacements:
+            darwin: apple-darwin
+            amd64: x86_64
+      command:
+        link:
+        - from: '**/bat'
+    ```
+
+Due to specifying `release.asset.filename` field, you can choose what you install explicitly. It's not only but also you can replace these `.OS` and `.Arch` with what you like.
+
+Above example will be templated from:
+
+```
+'{{ .Release.Name }}-{{ .Release.Tag }}-{{ .Arch }}-{{ .OS }}.tar.gz'
+```
+to:
+```
+bat-v0.11.0-x86_64-apple-darwin.tar.gz
+```
+
+
+### depends-on
+
+Type | Default
+---|---
+list | `[]`
+
+Allows you to specify dependency list between packages to handle hidden dependency that afx can't automatically infer.
+
+Explicitly specifying a dependency is helpful when a package relies on some other package's behavior. Concretely it's good for handling the order of loading files listed on `plugin.sources` when running `afx init`.
+
+Let's say you want to manage `pkg-a` and `pkg-b` with afx. Also let's say `pkg-a` needs to be loaded after `pkg-b` (This means `pkg-a` depends on `pkg-b`).
+
+In this case you can specify dependencies:
+
+=== "Case 1"
+
+    ```yaml hl_lines="9 10"
+    local:
+    - name: zsh
+      directory: ~/.zsh
+      plugin:
+        if: |
+          [[ $SHELL == *zsh* ]]
+        sources:
+        - '[0-9]*.zsh'
+      depends-on:
+      - google-cloud-sdk
+    - name: google-cloud-sdk
+      directory: ~/Downloads/google-cloud-sdk
+      plugin:
+        env:
+          PATH: ~/Downloads/google-cloud-sdk/bin
+        sources:
+        - '*.zsh.inc'
+    ```
+
+Thanks to `depends-on`, the order of loading sources are:
+
+```console
+* zsh -> google-cloud-sdk
+```
+
+Let's see the actual output with `afx init` in case we added `depends-on` like above config:
+
+```console
+$ afx init
+...
+source /Users/babarot/Downloads/google-cloud-sdk/completion.zsh.inc
+source /Users/babarot/Downloads/google-cloud-sdk/path.zsh.inc
+export PATH="$PATH:/Users/babarot/Downloads/google-cloud-sdk/bin"
+...
+source /Users/babarot/.zsh/10_utils.zsh
+source /Users/babarot/.zsh/20_keybinds.zsh
+source /Users/babarot/.zsh/30_aliases.zsh
+source /Users/babarot/.zsh/50_setopt.zsh
+source /Users/babarot/.zsh/70_misc.zsh
+...
+...
+```
+
+### command
+
+See [Command](../command.md) page
+
+### plugin
+
+See [Plugin](../plugin.md) page

--- a/docs/configuration/plugin.md
+++ b/docs/configuration/plugin.md
@@ -16,7 +16,7 @@ list | yes
 
     ```yaml hl_lines="9 10" title="Simple case, just register to init.sh as load scripts"
     github:
-    - name: enhancd
+    - name: b4b4r07/enhancd
       description: A next-generation cd command with your interactive filter
       owner: b4b4r07
       repo: enhancd
@@ -31,7 +31,7 @@ list | yes
 
     ```yaml hl_lines="10 11" title="Using wildcards to register multiple files"
     github:
-    - name: zsh-prompt-minimal
+    - name: b4b4r07/zsh-prompt-minimal
       description: Super super super minimal prompt for zsh
       owner: b4b4r07
       repo: zsh-prompt-minimal
@@ -74,7 +74,7 @@ list | no
 
     ```yaml hl_lines="7 8 9"
     github:
-    - name: zsh-prompt-minimal
+    - name: b4b4r07/zsh-prompt-minimal
       description: Super super super minimal prompt for zsh
       owner: b4b4r07
       repo: zsh-prompt-minimal
@@ -98,7 +98,7 @@ string | no
 
     ```yaml hl_lines="11 12 13" title="Login message if tpm is installed"
     github:
-    - name: enhancd
+    - name: b4b4r07/enhancd
       description: A next-generation cd command with your interactive filter
       owner: b4b4r07
       repo: enhancd

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ Let's say you want to install `jq` and `enhancd` with afx. So please write YAML 
 
 ```yaml
 github:
-- name: jq
+- name: stedolan/jq
   description: Command-line JSON processor
   owner: stedolan
   repo: jq
@@ -35,7 +35,7 @@ github:
     link:
     - from: '*jq*'
       to: jq
-- name: enhancd
+- name: b4b4r07/enhancd
   description: A next-generation cd command with your interactive filter
   owner: b4b4r07
   repo: enhancd
@@ -93,7 +93,7 @@ If you want to update package to new version etc, all you have to do is just to 
 
 ```diff
 github:
-  - name: jq
+  - name: stedolan/jq
     description: Command-line JSON processor
     owner: stedolan
     repo: jq

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -70,7 +70,7 @@ afx have a state feature like [Terraform](https://www.terraform.io/). In afx, du
 
     ```diff
       github:
-      - name: enhancd
+      - name: b4b4r07/enhancd
         description: A next-generation cd command with your interactive filter
         owner: b4b4r07
         repo: enhancd
@@ -79,7 +79,7 @@ afx have a state feature like [Terraform](https://www.terraform.io/). In afx, du
             ENHANCD_FILTER: fzf --height 25% --reverse --ansi:fzy
           sources:
           - init.sh
-    + - name: fzy
+    + - name: jhawthorn/fzy
     +   description: A better fuzzy finder
     +   owner: jhawthorn
     +   repo: fzy
@@ -100,7 +100,7 @@ afx have a state feature like [Terraform](https://www.terraform.io/). In afx, du
 
     ```diff
       github:
-      - name: enhancd
+      - name: b4b4r07/enhancd
         description: A next-generation cd command with your interactive filter
         owner: b4b4r07
         repo: enhancd
@@ -109,7 +109,7 @@ afx have a state feature like [Terraform](https://www.terraform.io/). In afx, du
             ENHANCD_FILTER: fzf --height 25% --reverse --ansi:fzy
           sources:
           - init.sh
-    - - name: fzy
+    - - name: jhawthorn/fzy
     -   description: A better fuzzy finder
     -   owner: jhawthorn
     -   repo: fzy

--- a/pkg/config/github.go
+++ b/pkg/config/github.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	afctx "github.com/b4b4r07/afx/pkg/context"
+	"github.com/b4b4r07/afx/pkg/data"
 	"github.com/b4b4r07/afx/pkg/errors"
 	"github.com/b4b4r07/afx/pkg/logging"
 	"github.com/b4b4r07/afx/pkg/tmpl"
@@ -51,8 +51,10 @@ type GitHubOption struct {
 
 // Release represents a GitHub release structure
 type Release struct {
-	Name     string   `yaml:"name" validate:"required"`
-	Tag      string   `yaml:"tag"`
+	Name string `yaml:"name" validate:"required"`
+	Tag  string `yaml:"tag"`
+
+	// TODO: (internal change): rename Artifact to Asset
 	Artifact Artifact `yaml:"asset"`
 }
 
@@ -353,14 +355,6 @@ func (c GitHub) InstallFromRelease(ctx context.Context) error {
 }
 
 func (c GitHub) templateFilename() (string, error) {
-	data := afctx.New(
-		afctx.WithPackage(c),
-		afctx.WithRelease(afctx.Release{
-			Name: c.Release.Name,
-			Tag:  c.Release.Tag,
-		}),
-	)
-
 	filename := c.Release.Artifact.Filename
 	replacements := c.Release.Artifact.Replacements
 
@@ -370,6 +364,14 @@ func (c GitHub) templateFilename() (string, error) {
 	}
 
 	log.Printf("[DEBUG] asset: templating filename from %q", filename)
+
+	data := data.New(
+		data.WithPackage(c),
+		data.WithRelease(data.Release{
+			Name: c.Release.Name,
+			Tag:  c.Release.Tag,
+		}),
+	)
 
 	filename, err := tmpl.New(data).
 		Replace(replacements).

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,80 @@
+package context
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+type Context struct {
+	Env     Env
+	Runtime Runtime
+	Package Package
+	Release Release
+}
+
+type Env map[string]string
+
+type Runtime struct {
+	Goos   string
+	Goarch string
+}
+
+type PackageInterface interface {
+	GetHome() string
+	GetName() string
+}
+
+type Package struct {
+	Name string
+	Home string
+}
+
+type Release struct {
+	Name string
+	Tag  string
+}
+
+func New(fields ...func(*Context)) *Context {
+	ctx := &Context{
+		Package: Package{},
+		Release: Release{},
+		Env:     ToEnv(os.Environ()),
+		Runtime: Runtime{
+			Goos:   runtime.GOOS,
+			Goarch: runtime.GOARCH,
+		},
+	}
+	for _, f := range fields {
+		f(ctx)
+	}
+	return ctx
+}
+
+func WithPackage(pkg PackageInterface) func(*Context) {
+	return func(ctx *Context) {
+		ctx.Package = Package{
+			Home: pkg.GetHome(),
+			Name: pkg.GetName(),
+		}
+	}
+}
+
+func WithRelease(r Release) func(*Context) {
+	return func(ctx *Context) {
+		ctx.Release = r
+	}
+}
+
+// ToEnv converts a list of strings to an Env (aka a map[string]string).
+func ToEnv(env []string) Env {
+	r := Env{}
+	for _, e := range env {
+		p := strings.SplitN(e, "=", 2)
+		if len(p) != 2 || p[0] == "" {
+			continue
+		}
+		r[p[0]] = p[1]
+	}
+	return r
+}

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -1,4 +1,4 @@
-package context
+package data
 
 import (
 	"os"
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-type Context struct {
+type Data struct {
 	Env     Env
 	Runtime Runtime
 	Package Package
@@ -35,8 +35,8 @@ type Release struct {
 	Tag  string
 }
 
-func New(fields ...func(*Context)) *Context {
-	ctx := &Context{
+func New(fields ...func(*Data)) *Data {
+	d := &Data{
 		Package: Package{},
 		Release: Release{},
 		Env:     ToEnv(os.Environ()),
@@ -46,23 +46,23 @@ func New(fields ...func(*Context)) *Context {
 		},
 	}
 	for _, f := range fields {
-		f(ctx)
+		f(d)
 	}
-	return ctx
+	return d
 }
 
-func WithPackage(pkg PackageInterface) func(*Context) {
-	return func(ctx *Context) {
-		ctx.Package = Package{
+func WithPackage(pkg PackageInterface) func(*Data) {
+	return func(d *Data) {
+		d.Package = Package{
 			Home: pkg.GetHome(),
 			Name: pkg.GetName(),
 		}
 	}
 }
 
-func WithRelease(r Release) func(*Context) {
-	return func(ctx *Context) {
-		ctx.Release = r
+func WithRelease(r Release) func(*Data) {
+	return func(d *Data) {
+		d.Release = r
 	}
 }
 

--- a/pkg/tmpl/tmpl.go
+++ b/pkg/tmpl/tmpl.go
@@ -1,0 +1,95 @@
+package tmpl
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/b4b4r07/afx/pkg/context"
+)
+
+// Template holds data that can be applied to a template string.
+type Template struct {
+	ctx    *context.Context
+	fields Fields
+}
+
+// Fields that will be available to the template engine.
+type Fields map[string]interface{}
+
+const (
+	pkgName = "Name"
+	pkgHome = "Home"
+	dir     = "Dir"
+	goos    = "OS"
+	goarch  = "Arch"
+	env     = "Env"
+	release = "Release"
+
+	// release
+	releaseName = "Name"
+	releaseTag  = "Tag"
+)
+
+// New Template.
+func New(ctx *context.Context) *Template {
+	return &Template{
+		ctx: ctx,
+		fields: Fields{
+			env:     ctx.Env,
+			pkgName: ctx.Package.Name,
+			pkgHome: ctx.Package.Home,
+			dir:     ctx.Package.Home,
+			goos:    ctx.Runtime.Goos,
+			goarch:  ctx.Runtime.Goarch,
+			release: map[string]string{
+				releaseName: ctx.Release.Name,
+				releaseTag:  ctx.Release.Tag,
+			},
+		},
+	}
+}
+
+// Apply applies the given string against the Fields stored in the template.
+func (t *Template) Apply(s string) (string, error) {
+	var out bytes.Buffer
+	tmpl, err := template.New("tmpl").
+		Option("missingkey=error").
+		Funcs(template.FuncMap{
+			"replace": strings.ReplaceAll,
+			"time": func(s string) string {
+				return time.Now().UTC().Format(s)
+			},
+			"tolower":    strings.ToLower,
+			"toupper":    strings.ToUpper,
+			"trim":       strings.TrimSpace,
+			"trimprefix": strings.TrimPrefix,
+			"trimsuffix": strings.TrimSuffix,
+			"dir":        filepath.Dir,
+			"abs":        filepath.Abs,
+		}).
+		Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	err = tmpl.Execute(&out, t.fields)
+	return out.String(), err
+}
+
+// Replace populates Fields from the artifact and replacements.
+func (t *Template) Replace(replacements map[string]string) *Template {
+	t.fields[goos] = replace(replacements, t.ctx.Runtime.Goos)
+	t.fields[goarch] = replace(replacements, t.ctx.Runtime.Goarch)
+	return t
+}
+
+func replace(replacements map[string]string, original string) string {
+	result := replacements[original]
+	if result == "" {
+		return original
+	}
+	return result
+}

--- a/pkg/tmpl/tmpl.go
+++ b/pkg/tmpl/tmpl.go
@@ -7,12 +7,12 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/b4b4r07/afx/pkg/context"
+	"github.com/b4b4r07/afx/pkg/data"
 )
 
 // Template holds data that can be applied to a template string.
 type Template struct {
-	ctx    *context.Context
+	data   *data.Data
 	fields Fields
 }
 
@@ -34,19 +34,19 @@ const (
 )
 
 // New Template.
-func New(ctx *context.Context) *Template {
+func New(d *data.Data) *Template {
 	return &Template{
-		ctx: ctx,
+		data: d,
 		fields: Fields{
-			env:     ctx.Env,
-			pkgName: ctx.Package.Name,
-			pkgHome: ctx.Package.Home,
-			dir:     ctx.Package.Home,
-			goos:    ctx.Runtime.Goos,
-			goarch:  ctx.Runtime.Goarch,
+			env:     d.Env,
+			pkgName: d.Package.Name,
+			pkgHome: d.Package.Home,
+			dir:     d.Package.Home,
+			goos:    d.Runtime.Goos,
+			goarch:  d.Runtime.Goarch,
 			release: map[string]string{
-				releaseName: ctx.Release.Name,
-				releaseTag:  ctx.Release.Tag,
+				releaseName: d.Release.Name,
+				releaseTag:  d.Release.Tag,
 			},
 		},
 	}
@@ -81,8 +81,8 @@ func (t *Template) Apply(s string) (string, error) {
 
 // Replace populates Fields from the artifact and replacements.
 func (t *Template) Replace(replacements map[string]string) *Template {
-	t.fields[goos] = replace(replacements, t.ctx.Runtime.Goos)
-	t.fields[goarch] = replace(replacements, t.ctx.Runtime.Goarch)
+	t.fields[goos] = replace(replacements, t.data.Runtime.Goos)
+	t.fields[goarch] = replace(replacements, t.data.Runtime.Goarch)
 	return t
 }
 


### PR DESCRIPTION
## WHAT

- Add `release.asset.filename` to specify filename directly instead of automatic asset filtering feature by afx internally
- Add `release.asset.replacements` to replace OS/Arch wording with user-defined values corresponding to GOOS/GOARCH.

## WHY

Make afx installation more flexible and powerful.