### PR TITLE
Update state logic

### DIFF
--- a/cmd/state.go
+++ b/cmd/state.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/b4b4r07/afx/pkg/errors"
 	"github.com/b4b4r07/afx/pkg/templates"
 	"github.com/fatih/color"
@@ -11,6 +12,12 @@ import (
 
 type stateCmd struct {
 	meta
+
+	opt stateOpt
+}
+
+type stateOpt struct {
+	force bool
 }
 
 var (
@@ -23,8 +30,12 @@ var (
 
 // newStateCmd creates a new state command
 func newStateCmd() *cobra.Command {
+	c := &stateCmd{
+		opt: stateOpt{},
+	}
+
 	stateCmd := &cobra.Command{
-		Use:                   "state [list|refresh]",
+		Use:                   "state [list|refresh|remove]",
 		Short:                 "Advanced state management",
 		Long:                  stateLong,
 		Example:               stateExample,
@@ -35,21 +46,21 @@ func newStateCmd() *cobra.Command {
 		Hidden:                true,
 	}
 
-	stateListCmd := newStateListCmd()
-	stateRefreshCmd := newStateRefreshCmd()
-	stateRefreshCmd.Flags().BoolP("force", "", false, "Force update")
+	stateListCmd := c.newStateListCmd()
+	stateRefreshCmd := c.newStateRefreshCmd()
+	stateRefreshCmd.Flags().BoolVarP(&c.opt.force, "force", "", false, "force update")
+	stateRemoveCmd := c.newStateRemoveCmd()
 
 	stateCmd.AddCommand(
 		stateListCmd,
 		stateRefreshCmd,
+		stateRemoveCmd,
 	)
 
 	return stateCmd
 }
 
-func newStateListCmd() *cobra.Command {
-	c := &stateCmd{}
-
+func (c stateCmd) newStateListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:                   "list",
 		Short:                 "List your state items",
@@ -60,17 +71,20 @@ func newStateListCmd() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return c.meta.init(args)
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			for _, pkg := range c.State.NoChanges {
-				fmt.Println(pkg.GetName())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			items, err := c.State.List()
+			if err != nil {
+				return err
 			}
+			for _, item := range items {
+				fmt.Println(item)
+			}
+			return nil
 		},
 	}
 }
 
-func newStateRefreshCmd() *cobra.Command {
-	c := &stateCmd{}
-
+func (c stateCmd) newStateRefreshCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:                   "refresh",
 		Short:                 "Refresh your state file",
@@ -82,18 +96,51 @@ func newStateRefreshCmd() *cobra.Command {
 			return c.meta.init(args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			force, err := cmd.Flags().GetBool("force")
-			if err != nil {
-				return err
-			}
-			if force {
+			if c.opt.force {
 				return c.State.New()
 			}
-
 			if err := c.State.Refresh(); err != nil {
 				return errors.Wrap(err, "failed to refresh state")
 			}
 			fmt.Println(color.WhiteString("Successfully refreshed"))
+			return nil
+		},
+	}
+}
+
+func (c stateCmd) newStateRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                   "remove",
+		Short:                 "Remove selected packages from state file",
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		Aliases:               []string{"rm"},
+		Args:                  cobra.MinimumNArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.meta.init(args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var selected []string
+			switch len(cmd.Flags().Args()) {
+			case 0:
+				resources, err := c.State.List()
+				if err != nil {
+					return errors.Wrap(err, "failed to list state items")
+				}
+				prompt := &survey.MultiSelect{
+					Message:  "Choose a package:",
+					Options:  resources,
+					PageSize: 10,
+				}
+				survey.AskOne(prompt, &selected)
+			default:
+				// TODO: check valid or invalid
+				selected = cmd.Flags().Args()
+			}
+			for _, resource := range selected {
+				c.State.Remove(resource)
+			}
 			return nil
 		},
 	}

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -30,9 +30,7 @@ var (
 
 // newStateCmd creates a new state command
 func newStateCmd() *cobra.Command {
-	c := &stateCmd{
-		opt: stateOpt{},
-	}
+	c := &stateCmd{}
 
 	stateCmd := &cobra.Command{
 		Use:                   "state [list|refresh|remove]",
@@ -44,17 +42,15 @@ func newStateCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Args:                  cobra.MaximumNArgs(1),
 		Hidden:                true,
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			return c.meta.init(args)
+		},
 	}
 
-	stateListCmd := c.newStateListCmd()
-	stateRefreshCmd := c.newStateRefreshCmd()
-	stateRefreshCmd.Flags().BoolVarP(&c.opt.force, "force", "", false, "force update")
-	stateRemoveCmd := c.newStateRemoveCmd()
-
 	stateCmd.AddCommand(
-		stateListCmd,
-		stateRefreshCmd,
-		stateRemoveCmd,
+		c.newStateListCmd(),
+		c.newStateRefreshCmd(),
+		c.newStateRemoveCmd(),
 	)
 
 	return stateCmd
@@ -67,7 +63,7 @@ func (c stateCmd) newStateListCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
-		Args:                  cobra.MaximumNArgs(0),
+		Args:                  cobra.ExactArgs(0),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return c.meta.init(args)
 		},
@@ -85,13 +81,13 @@ func (c stateCmd) newStateListCmd() *cobra.Command {
 }
 
 func (c stateCmd) newStateRefreshCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:                   "refresh",
 		Short:                 "Refresh your state file",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
-		Args:                  cobra.MaximumNArgs(0),
+		Args:                  cobra.ExactArgs(0),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return c.meta.init(args)
 		},
@@ -106,6 +102,8 @@ func (c stateCmd) newStateRefreshCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVarP(&c.opt.force, "force", "", false, "force update")
+	return cmd
 }
 
 func (c stateCmd) newStateRemoveCmd() *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.0.2
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/creativeprojects/go-selfupdate v0.6.1

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -41,7 +41,8 @@ type State struct {
 	// Something changes happened between config file and state file
 	// Currently only version (github.release.tag) is detected as changes
 	Changes []config.Package
-	//
+	// All items recorded in state file. It means no changes between state file
+	// and config file
 	NoChanges []config.Package
 }
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -324,6 +324,28 @@ func (s *State) Update(pkg config.Package) {
 	s.save()
 }
 
+func (s *State) List() ([]string, error) {
+	_, err := os.Stat(s.path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return []string{}, err
+	default:
+		content, err := ioutil.ReadFile(s.path)
+		if err != nil {
+			return []string{}, err
+		}
+		var state Self
+		if err := json.Unmarshal(content, &state); err != nil {
+			return []string{}, err
+		}
+		var items []string
+		for k := range state.Resources {
+			items = append(items, k)
+		}
+		return items, nil
+	}
+}
+
 func (s *State) New() error {
 	s.Resources = map[string]Resource{}
 	for _, pkg := range s.packages {


### PR DESCRIPTION
## WHAT

- Use state.ID instead of state.Name
- Add state rm command
- Add annotation feature related to bump up version

## WHY

Currently in state file, each state name is same as pkg name.
But if using pkg.name as state.name, it may be problem:

- changing pkg.name in config file by users

this operation will be regarded as adding new package and
removing that package.

so we need fixed string not depending on pkg.name