### PR TITLE
Refactor meta command

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -7,10 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type completionCmd struct {
-	meta
-}
-
 var (
 	// completionLong is long description of completion command
 	completionLong = templates.LongDesc(``)
@@ -51,10 +47,8 @@ var (
 )
 
 // newCompletionCmd creates a new completion command
-func newCompletionCmd() *cobra.Command {
-	c := &completionCmd{}
-
-	completionCmd := &cobra.Command{
+func (m metaCmd) newCompletionCmd() *cobra.Command {
+	return &cobra.Command{
 		Use:                   "completion [bash|zsh|fish]",
 		Short:                 "Generate completion script",
 		Long:                  completionLong,
@@ -65,20 +59,15 @@ func newCompletionCmd() *cobra.Command {
 		ValidArgs:             []string{"bash", "zsh", "fish"},
 		Args:                  cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.meta.init(args); err != nil {
-				return err
-			}
 			switch args[0] {
 			case "bash":
-				newRootCmd().GenBashCompletion(os.Stdout)
+				newRootCmd(m).GenBashCompletion(os.Stdout)
 			case "zsh":
-				newRootCmd().GenZshCompletion(os.Stdout)
+				newRootCmd(m).GenZshCompletion(os.Stdout)
 			case "fish":
-				newRootCmd().GenFishCompletion(os.Stdout, true)
+				newRootCmd(m).GenFishCompletion(os.Stdout, true)
 			}
 			return nil
 		},
 	}
-
-	return completionCmd
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -41,7 +41,7 @@ func (m metaCmd) newInitCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Args:                  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			for _, pkg := range m.Packages {
+			for _, pkg := range m.packages {
 				if err := pkg.Init(); err != nil {
 					log.Printf("[ERROR] %s: failed to init pacakge: %v\n", pkg.GetName(), err)
 					// do not return err to continue to load even if failed

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,18 +1,11 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/b4b4r07/afx/pkg/helpers/templates"
 	"github.com/spf13/cobra"
 )
-
-type initCmd struct {
-	meta
-
-	path string
-}
 
 var (
 	// initLong is long description of init command
@@ -37,10 +30,8 @@ var (
 )
 
 // newInitCmd creates a new init command
-func newInitCmd() *cobra.Command {
-	c := &initCmd{}
-
-	initCmd := &cobra.Command{
+func (m metaCmd) newInitCmd() *cobra.Command {
+	return &cobra.Command{
 		Use:                   "init",
 		Short:                 "Initialize installed packages",
 		Long:                  initLong,
@@ -49,32 +40,14 @@ func newInitCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.MaximumNArgs(0),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.meta.init(args); err != nil {
-				return err
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, pkg := range m.Packages {
+				if err := pkg.Init(); err != nil {
+					log.Printf("[ERROR] %s: failed to init pacakge: %v\n", pkg.GetName(), err)
+					// do not return err to continue to load even if failed
+					continue
+				}
 			}
-			return c.run(args)
 		},
 	}
-
-	return initCmd
-}
-
-func (c *initCmd) run(args []string) error {
-	for _, pkg := range c.Packages {
-		// if has init config,
-		// print pkg name, e.g. fmt.Printf("# %s\n", pkg.GetHome())
-		// endif
-		if err := pkg.Init(); err != nil {
-			log.Printf("[ERROR] %s: failed to init pacakge: %v\n", pkg.GetName(), err)
-			// do not return err to continue to load even if failed
-			continue
-		}
-	}
-
-	if c.path != "" {
-		fmt.Printf("export PATH=$PATH:%s\n", c.path)
-	}
-
-	return nil
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -46,9 +46,9 @@ func (m metaCmd) newInstallCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.MinimumNArgs(0),
-		ValidArgs:             getNameInPackages(m.State.Additions),
+		ValidArgs:             getNameInPackages(m.state.Additions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pkgs := append(m.State.Additions, m.State.Readditions...)
+			pkgs := append(m.state.Additions, m.state.Readditions...)
 			if len(pkgs) == 0 {
 				fmt.Println("No packages to install")
 				return nil
@@ -75,7 +75,7 @@ func (m metaCmd) newInstallCmd() *cobra.Command {
 				return nil
 			}
 
-			m.Env.AskWhen(map[string]bool{
+			m.env.AskWhen(map[string]bool{
 				"GITHUB_TOKEN":      config.HasGitHubReleaseBlock(pkgs),
 				"AFX_SUDO_PASSWORD": config.HasSudoInCommandBuildSteps(pkgs),
 			})
@@ -118,7 +118,7 @@ func (c *installCmd) run(pkgs []config.Package) error {
 			err := pkg.Install(ctx, completion)
 			switch err {
 			case nil:
-				c.State.Add(pkg)
+				c.state.Add(pkg)
 			default:
 				log.Printf("[DEBUG] uninstall %q because installation failed", pkg.GetName())
 				pkg.Uninstall(ctx)
@@ -149,7 +149,7 @@ func (c *installCmd) run(pkgs []config.Package) error {
 
 	defer func(err error) {
 		if err != nil {
-			c.Env.Refresh()
+			c.env.Refresh()
 		}
 	}(exit.ErrorOrNil())
 
@@ -157,7 +157,7 @@ func (c *installCmd) run(pkgs []config.Package) error {
 }
 
 func (c *installCmd) getFromAdditions(name string) (config.Package, error) {
-	pkgs := append(c.State.Additions, c.State.Readditions...)
+	pkgs := append(c.state.Additions, c.state.Readditions...)
 
 	for _, pkg := range pkgs {
 		if pkg.GetName() == name {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -15,7 +15,7 @@ import (
 )
 
 type installCmd struct {
-	meta
+	metaCmd
 }
 
 var (
@@ -33,8 +33,8 @@ var (
 )
 
 // newInstallCmd creates a new fmt command
-func newInstallCmd() *cobra.Command {
-	c := &installCmd{}
+func (m metaCmd) newInstallCmd() *cobra.Command {
+	c := &installCmd{m}
 
 	installCmd := &cobra.Command{
 		Use:                   "install",
@@ -46,11 +46,8 @@ func newInstallCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.MinimumNArgs(0),
+		ValidArgs:             getNameInPackages(m.State.Additions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.meta.init(args); err != nil {
-				return err
-			}
-
 			pkgs := append(c.State.Additions, c.State.Readditions...)
 			if len(pkgs) == 0 {
 				fmt.Println("No packages to install")
@@ -86,7 +83,7 @@ func newInstallCmd() *cobra.Command {
 			return c.run(pkgs)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.meta.printForUpdate()
+			return c.printForUpdate()
 		},
 	}
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -34,7 +34,7 @@ var (
 
 // newInstallCmd creates a new fmt command
 func (m metaCmd) newInstallCmd() *cobra.Command {
-	c := &installCmd{m}
+	c := &installCmd{metaCmd: m}
 
 	installCmd := &cobra.Command{
 		Use:                   "install",
@@ -48,7 +48,7 @@ func (m metaCmd) newInstallCmd() *cobra.Command {
 		Args:                  cobra.MinimumNArgs(0),
 		ValidArgs:             getNameInPackages(m.State.Additions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pkgs := append(c.State.Additions, c.State.Readditions...)
+			pkgs := append(m.State.Additions, m.State.Readditions...)
 			if len(pkgs) == 0 {
 				fmt.Println("No packages to install")
 				return nil
@@ -69,13 +69,13 @@ func (m metaCmd) newInstallCmd() *cobra.Command {
 				pkgs = given
 			}
 
-			yes, _ := c.askRunCommand(*c, getNameInPackages(pkgs))
+			yes, _ := m.askRunCommand(*c, getNameInPackages(pkgs))
 			if !yes {
 				fmt.Println("Cancelled")
 				return nil
 			}
 
-			c.Env.AskWhen(map[string]bool{
+			m.Env.AskWhen(map[string]bool{
 				"GITHUB_TOKEN":      config.HasGitHubReleaseBlock(pkgs),
 				"AFX_SUDO_PASSWORD": config.HasSudoInCommandBuildSteps(pkgs),
 			})
@@ -83,7 +83,7 @@ func (m metaCmd) newInstallCmd() *cobra.Command {
 			return c.run(pkgs)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.printForUpdate()
+			return m.printForUpdate()
 		},
 	}
 

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -21,7 +21,7 @@ import (
 	"github.com/fatih/color"
 )
 
-type meta struct {
+type metaCmd struct {
 	Env       *env.Config
 	Packages  []config.Package
 	AppConfig *config.AppConfig
@@ -30,7 +30,7 @@ type meta struct {
 	updateMessageChan chan *update.ReleaseInfo
 }
 
-func (m *meta) init(args []string) error {
+func (m *metaCmd) init() error {
 	m.updateMessageChan = make(chan *update.ReleaseInfo)
 	go func() {
 		log.Printf("[DEBUG] (goroutine): checking new updates...")
@@ -147,7 +147,7 @@ func printForUpdate(uriCh chan *update.ReleaseInfo) {
 	}
 }
 
-func (m *meta) printForUpdate() error {
+func (m *metaCmd) printForUpdate() error {
 	if m.updateMessageChan == nil {
 		return errors.New("update message chan is not set")
 	}
@@ -155,7 +155,7 @@ func (m *meta) printForUpdate() error {
 	return nil
 }
 
-func (m *meta) prompt() (config.Package, error) {
+func (m *metaCmd) prompt() (config.Package, error) {
 	var stdin, stdout bytes.Buffer
 
 	cmd := shell.Shell{
@@ -193,7 +193,7 @@ func (m *meta) prompt() (config.Package, error) {
 	return nil, errors.New("pkg not found")
 }
 
-func (m *meta) askRunCommand(op interface{}, pkgs []string) (bool, error) {
+func (m *metaCmd) askRunCommand(op interface{}, pkgs []string) (bool, error) {
 	var do string
 	switch op.(type) {
 	case installCmd:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var (
 )
 
 // newRootCmd returns the root command
-func newRootCmd() *cobra.Command {
+func newRootCmd(m metaCmd) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:                "afx",
 		Short:              "Package manager for CLI",
@@ -63,20 +63,20 @@ func newRootCmd() *cobra.Command {
 		},
 	}
 
-	rootCmd.AddCommand(newInitCmd())
-	rootCmd.AddCommand(newInstallCmd())
-	rootCmd.AddCommand(newUninstallCmd())
-	rootCmd.AddCommand(newUpdateCmd())
-	rootCmd.AddCommand(newSelfUpdateCmd())
-	rootCmd.AddCommand(newShowCmd())
-
-	rootCmd.AddCommand(newCompletionCmd())
-	rootCmd.AddCommand(newStateCmd())
+	rootCmd.AddCommand(
+		m.newInitCmd(),
+		m.newInstallCmd(),
+		m.newUninstallCmd(),
+		m.newUpdateCmd(),
+		m.newSelfUpdateCmd(),
+		m.newShowCmd(),
+		m.newCompletionCmd(),
+		m.newStateCmd(),
+	)
 
 	return rootCmd
 }
 
-// Execute is
 func Execute() error {
 	logWriter, err := logging.LogOutput()
 	if err != nil {
@@ -89,6 +89,11 @@ func Execute() error {
 	log.Printf("[INFO] Build tag/SHA: %s/%s", BuildTag, BuildSHA)
 	log.Printf("[INFO] CLI args: %#v", os.Args)
 
+	meta := metaCmd{}
+	if err := meta.init(); err != nil {
+		return errors.Wrap(err, "failed to initialize afx")
+	}
+
 	defer log.Printf("[INFO] root command execution finished")
-	return newRootCmd().Execute()
+	return newRootCmd(meta).Execute()
 }

--- a/cmd/self-update.go
+++ b/cmd/self-update.go
@@ -25,7 +25,7 @@ import (
 )
 
 type selfUpdateCmd struct {
-	meta
+	metaCmd
 
 	opt selfUpdateOpt
 
@@ -53,9 +53,10 @@ var (
 )
 
 // newSelfUpdateCmd creates a new selfUpdate command
-func newSelfUpdateCmd() *cobra.Command {
+func (m metaCmd) newSelfUpdateCmd() *cobra.Command {
 	info := color.New(color.FgGreen).SprintFunc()
 	c := &selfUpdateCmd{
+		metaCmd: m,
 		annotation: map[string]string{
 			"0.1.11": info(`Run "afx state refresh --force" at first!`),
 		},
@@ -71,10 +72,6 @@ func newSelfUpdateCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Args:                  cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.meta.init(args); err != nil {
-				return err
-			}
-
 			if c.opt.tag {
 				return c.selectTag(args)
 			}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 
 	"github.com/b4b4r07/afx/pkg/config"
-	"github.com/b4b4r07/afx/pkg/printers"
 	"github.com/b4b4r07/afx/pkg/helpers/templates"
+	"github.com/b4b4r07/afx/pkg/printers"
 	"github.com/spf13/cobra"
 )
 
 type showCmd struct {
-	meta
+	metaCmd
 }
 
 var (
@@ -27,8 +27,8 @@ var (
 )
 
 // newShowCmd creates a new show command
-func newShowCmd() *cobra.Command {
-	c := &showCmd{}
+func (m metaCmd) newShowCmd() *cobra.Command {
+	c := &showCmd{m}
 
 	showCmd := &cobra.Command{
 		Use:                   "show",
@@ -40,9 +40,6 @@ func newShowCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Args:                  cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.meta.init(args); err != nil {
-				return err
-			}
 			return c.run(args)
 		},
 	}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -78,28 +78,28 @@ func (c *showCmd) run(args []string) error {
 	}
 
 	var items []Item
-	for _, pkg := range append(c.State.Additions, c.State.Readditions...) {
+	for _, pkg := range append(c.state.Additions, c.state.Readditions...) {
 		items = append(items, Item{
 			Name:   pkg.GetName(),
 			Type:   getType(pkg),
 			Status: "WaitingInstall",
 		})
 	}
-	for _, pkg := range c.State.Changes {
+	for _, pkg := range c.state.Changes {
 		items = append(items, Item{
 			Name:   pkg.GetName(),
 			Type:   getType(pkg),
 			Status: "WaitingUpdate",
 		})
 	}
-	for _, resource := range c.State.Deletions {
+	for _, resource := range c.state.Deletions {
 		items = append(items, Item{
 			Name:   resource.Name,
 			Type:   resource.Type,
 			Status: "WaitingUninstall",
 		})
 	}
-	for _, pkg := range c.State.NoChanges {
+	for _, pkg := range c.state.NoChanges {
 		items = append(items, Item{
 			Name:   pkg.GetName(),
 			Type:   getType(pkg),

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -106,6 +106,7 @@ func (c stateCmd) newStateRemoveCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Aliases:               []string{"rm"},
 		Args:                  cobra.MinimumNArgs(0),
+		ValidArgs:             getNameInPackages(c.State.NoChanges),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resources []string
 			switch len(cmd.Flags().Args()) {
@@ -127,7 +128,8 @@ func (c stateCmd) newStateRemoveCmd() *cobra.Command {
 				resources = cmd.Flags().Args()
 			}
 			for _, resource := range resources {
-				c.State.Remove(resource)
+				id := c.State.ToID(resource)
+				c.State.Remove(id)
 			}
 			return nil
 		},

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -11,7 +11,7 @@ import (
 )
 
 type stateCmd struct {
-	meta
+	metaCmd
 
 	opt stateOpt
 }
@@ -29,8 +29,8 @@ var (
 )
 
 // newStateCmd creates a new state command
-func newStateCmd() *cobra.Command {
-	c := &stateCmd{}
+func (m metaCmd) newStateCmd() *cobra.Command {
+	c := &stateCmd{metaCmd: m}
 
 	stateCmd := &cobra.Command{
 		Use:                   "state [list|refresh|remove]",
@@ -42,9 +42,6 @@ func newStateCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Args:                  cobra.MaximumNArgs(1),
 		Hidden:                true,
-		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.meta.init(args)
-		},
 	}
 
 	stateCmd.AddCommand(
@@ -64,9 +61,6 @@ func (c stateCmd) newStateListCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.ExactArgs(0),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.meta.init(args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			items, err := c.State.List()
 			if err != nil {
@@ -88,9 +82,6 @@ func (c stateCmd) newStateRefreshCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.ExactArgs(0),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.meta.init(args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if c.opt.force {
 				return c.State.New()
@@ -115,9 +106,6 @@ func (c stateCmd) newStateRemoveCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Aliases:               []string{"rm"},
 		Args:                  cobra.MinimumNArgs(0),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.meta.init(args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resources []string
 			switch len(cmd.Flags().Args()) {

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -62,7 +62,7 @@ func (c stateCmd) newStateListCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Args:                  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			items, err := c.State.List()
+			items, err := c.state.List()
 			if err != nil {
 				return err
 			}
@@ -84,9 +84,9 @@ func (c stateCmd) newStateRefreshCmd() *cobra.Command {
 		Args:                  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if c.opt.force {
-				return c.State.New()
+				return c.state.New()
 			}
-			if err := c.State.Refresh(); err != nil {
+			if err := c.state.Refresh(); err != nil {
 				return errors.Wrap(err, "failed to refresh state")
 			}
 			fmt.Println(color.WhiteString("Successfully refreshed"))
@@ -106,12 +106,12 @@ func (c stateCmd) newStateRemoveCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Aliases:               []string{"rm"},
 		Args:                  cobra.MinimumNArgs(0),
-		ValidArgs:             getNameInPackages(c.State.NoChanges),
+		ValidArgs:             getNameInPackages(c.state.NoChanges),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resources []string
 			switch len(cmd.Flags().Args()) {
 			case 0:
-				list, err := c.State.List()
+				list, err := c.state.List()
 				if err != nil {
 					return errors.Wrap(err, "failed to list state items")
 				}
@@ -128,8 +128,8 @@ func (c stateCmd) newStateRemoveCmd() *cobra.Command {
 				resources = cmd.Flags().Args()
 			}
 			for _, resource := range resources {
-				id := c.State.ToID(resource)
-				c.State.Remove(id)
+				id := c.state.ToID(resource)
+				c.state.Remove(id)
 			}
 			return nil
 		},

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -43,9 +43,9 @@ func (m metaCmd) newUninstallCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.MinimumNArgs(0),
-		ValidArgs:             getNameInResources(m.State.Deletions),
+		ValidArgs:             getNameInResources(m.state.Deletions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resources := m.State.Deletions
+			resources := m.state.Deletions
 			if len(resources) == 0 {
 				fmt.Println("No packages to uninstall")
 				return nil
@@ -91,7 +91,7 @@ func (c *uninstallCmd) run(resources []state.Resource) error {
 			errs.Append(err)
 			continue
 		}
-		c.State.Remove(resource.ID)
+		c.state.Remove(resource.ID)
 		fmt.Printf("deleted %s\n", resource.Home)
 	}
 
@@ -107,7 +107,7 @@ func delete(paths ...string) error {
 }
 
 func (c *uninstallCmd) getFromDeletions(name string) (state.Resource, error) {
-	resources := c.State.Deletions
+	resources := c.state.Deletions
 
 	for _, resource := range resources {
 		if resource.Name == name {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -5,13 +5,13 @@ import (
 	"os"
 
 	"github.com/b4b4r07/afx/pkg/errors"
-	"github.com/b4b4r07/afx/pkg/state"
 	"github.com/b4b4r07/afx/pkg/helpers/templates"
+	"github.com/b4b4r07/afx/pkg/state"
 	"github.com/spf13/cobra"
 )
 
 type uninstallCmd struct {
-	meta
+	metaCmd
 }
 
 var (
@@ -29,8 +29,8 @@ var (
 )
 
 // newUninstallCmd creates a new uninstall command
-func newUninstallCmd() *cobra.Command {
-	c := &uninstallCmd{}
+func (m metaCmd) newUninstallCmd() *cobra.Command {
+	c := &uninstallCmd{m}
 
 	uninstallCmd := &cobra.Command{
 		Use:                   "uninstall",
@@ -43,11 +43,8 @@ func newUninstallCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.MinimumNArgs(0),
+		ValidArgs:             getNameInResources(m.State.Deletions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.meta.init(args); err != nil {
-				return err
-			}
-
 			resources := c.State.Deletions
 			if len(resources) == 0 {
 				fmt.Println("No packages to uninstall")
@@ -78,7 +75,7 @@ func newUninstallCmd() *cobra.Command {
 			return c.run(resources)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.meta.printForUpdate()
+			return c.printForUpdate()
 		},
 	}
 
@@ -94,7 +91,7 @@ func (c *uninstallCmd) run(resources []state.Resource) error {
 			errs.Append(err)
 			continue
 		}
-		c.State.Remove(resource.Name)
+		c.State.Remove(resource.ID)
 		fmt.Printf("deleted %s\n", resource.Home)
 	}
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -30,7 +30,7 @@ var (
 
 // newUninstallCmd creates a new uninstall command
 func (m metaCmd) newUninstallCmd() *cobra.Command {
-	c := &uninstallCmd{m}
+	c := &uninstallCmd{metaCmd: m}
 
 	uninstallCmd := &cobra.Command{
 		Use:                   "uninstall",
@@ -45,7 +45,7 @@ func (m metaCmd) newUninstallCmd() *cobra.Command {
 		Args:                  cobra.MinimumNArgs(0),
 		ValidArgs:             getNameInResources(m.State.Deletions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resources := c.State.Deletions
+			resources := m.State.Deletions
 			if len(resources) == 0 {
 				fmt.Println("No packages to uninstall")
 				return nil
@@ -66,7 +66,7 @@ func (m metaCmd) newUninstallCmd() *cobra.Command {
 				resources = given
 			}
 
-			yes, _ := c.askRunCommand(*c, getNameInResources(resources))
+			yes, _ := m.askRunCommand(*c, getNameInResources(resources))
 			if !yes {
 				fmt.Println("Cancelled")
 				return nil
@@ -75,7 +75,7 @@ func (m metaCmd) newUninstallCmd() *cobra.Command {
 			return c.run(resources)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.printForUpdate()
+			return m.printForUpdate()
 		},
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -15,7 +15,7 @@ import (
 )
 
 type updateCmd struct {
-	meta
+	metaCmd
 }
 
 var (
@@ -33,8 +33,8 @@ var (
 )
 
 // newUpdateCmd creates a new fmt command
-func newUpdateCmd() *cobra.Command {
-	c := &updateCmd{}
+func (m metaCmd) newUpdateCmd() *cobra.Command {
+	c := &updateCmd{m}
 
 	updateCmd := &cobra.Command{
 		Use:                   "update",
@@ -46,11 +46,8 @@ func newUpdateCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.MinimumNArgs(0),
+		ValidArgs:             getNameInPackages(m.State.Additions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.meta.init(args); err != nil {
-				return err
-			}
-
 			pkgs := c.State.Changes
 			if len(pkgs) == 0 {
 				fmt.Println("No packages to update")
@@ -86,7 +83,7 @@ func newUpdateCmd() *cobra.Command {
 			return c.run(pkgs)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.meta.printForUpdate()
+			return c.printForUpdate()
 		},
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -46,9 +46,9 @@ func (m metaCmd) newUpdateCmd() *cobra.Command {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		Args:                  cobra.MinimumNArgs(0),
-		ValidArgs:             getNameInPackages(m.State.Additions),
+		ValidArgs:             getNameInPackages(m.state.Additions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pkgs := m.State.Changes
+			pkgs := m.state.Changes
 			if len(pkgs) == 0 {
 				fmt.Println("No packages to update")
 				return nil
@@ -75,7 +75,7 @@ func (m metaCmd) newUpdateCmd() *cobra.Command {
 				return nil
 			}
 
-			m.Env.AskWhen(map[string]bool{
+			m.env.AskWhen(map[string]bool{
 				"GITHUB_TOKEN":      config.HasGitHubReleaseBlock(pkgs),
 				"AFX_SUDO_PASSWORD": config.HasSudoInCommandBuildSteps(pkgs),
 			})
@@ -118,7 +118,7 @@ func (c *updateCmd) run(pkgs []config.Package) error {
 			err := pkg.Install(ctx, completion)
 			switch err {
 			case nil:
-				c.State.Update(pkg)
+				c.state.Update(pkg)
 			}
 			select {
 			case results <- updateResult{Package: pkg, Error: err}:
@@ -145,7 +145,7 @@ func (c *updateCmd) run(pkgs []config.Package) error {
 
 	defer func(err error) {
 		if err != nil {
-			c.Env.Refresh()
+			c.env.Refresh()
 		}
 	}(exit.ErrorOrNil())
 
@@ -153,7 +153,7 @@ func (c *updateCmd) run(pkgs []config.Package) error {
 }
 
 func (c *updateCmd) getFromChanges(name string) (config.Package, error) {
-	pkgs := c.State.Changes
+	pkgs := c.state.Changes
 
 	for _, pkg := range pkgs {
 		if pkg.GetName() == name {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,7 +34,7 @@ var (
 
 // newUpdateCmd creates a new fmt command
 func (m metaCmd) newUpdateCmd() *cobra.Command {
-	c := &updateCmd{m}
+	c := &updateCmd{metaCmd: m}
 
 	updateCmd := &cobra.Command{
 		Use:                   "update",
@@ -48,7 +48,7 @@ func (m metaCmd) newUpdateCmd() *cobra.Command {
 		Args:                  cobra.MinimumNArgs(0),
 		ValidArgs:             getNameInPackages(m.State.Additions),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pkgs := c.State.Changes
+			pkgs := m.State.Changes
 			if len(pkgs) == 0 {
 				fmt.Println("No packages to update")
 				return nil
@@ -69,13 +69,13 @@ func (m metaCmd) newUpdateCmd() *cobra.Command {
 				pkgs = given
 			}
 
-			yes, _ := c.askRunCommand(*c, getNameInPackages(pkgs))
+			yes, _ := m.askRunCommand(*c, getNameInPackages(pkgs))
 			if !yes {
 				fmt.Println("Cancelled")
 				return nil
 			}
 
-			c.Env.AskWhen(map[string]bool{
+			m.Env.AskWhen(map[string]bool{
 				"GITHUB_TOKEN":      config.HasGitHubReleaseBlock(pkgs),
 				"AFX_SUDO_PASSWORD": config.HasSudoInCommandBuildSteps(pkgs),
 			})
@@ -83,7 +83,7 @@ func (m metaCmd) newUpdateCmd() *cobra.Command {
 			return c.run(pkgs)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.printForUpdate()
+			return m.printForUpdate()
 		},
 	}
 

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -108,7 +108,7 @@ func (c Command) GetLink(pkg Package) ([]Link, error) {
 			return links, errors.Wrapf(err, "%s: failed to get links", pkg.GetName())
 		}
 
-		log.Printf("[DEBUG] Run file globbing: %s", file)
+		log.Printf("[TRACE] Run zglob.Glob() to search files: %s", file)
 		var src string
 		switch len(matches) {
 		case 0:

--- a/pkg/config/github.go
+++ b/pkg/config/github.go
@@ -411,7 +411,7 @@ func (as *Assets) filter(fn func(Asset) bool) *Assets {
 	var assets Assets
 	if len(*as) < 2 {
 		// no more need to filter
-		log.Printf("[DEBUG] assets.filter: stopped because assets is already filtered to one or zero asset")
+		log.Printf("[DEBUG] assets.filter: finished filtering because length of assets is less than two")
 		return as
 	}
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -151,11 +151,15 @@ func remove(id ID, s *State) {
 	resources := map[ID]Resource{}
 	for _, resource := range s.Resources {
 		if resource.ID == id {
+			log.Printf("[DEBUG] %s: removed from state", id)
 			continue
 		}
 		resources[resource.ID] = resource
 	}
-	log.Printf("[DEBUG] %s: removed from state", id)
+	if len(s.Resources) == len(resources) {
+		log.Printf("[WARN] %s: failed to remove from state", id)
+		return
+	}
 	s.Resources = resources
 }
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -357,6 +357,15 @@ func (s *State) List() ([]string, error) {
 	}
 }
 
+func (s *State) ToID(name string) ID {
+	for _, pkg := range s.NoChanges {
+		if pkg.GetName() == name {
+			return getStateID(pkg)
+		}
+	}
+	return ""
+}
+
 func (s *State) New() error {
 	s.Resources = map[ID]Resource{}
 	for _, pkg := range s.packages {


### PR DESCRIPTION
## WHAT

Refactor meta command. `meta is used in various command in afx. It's basically for embedding to each subcommand to access meta information (e.g. env, packages, state etc...). In this PR, it has been moved to outside of each command. Concretely, will be moved to rootCmd.

By this, each commands doesn't have to run `meta.init()` with inside of its own. Each command can access `meta` via its receiver. Also, each command can continuously embed `meta` into its own subcommand to pass `meta` to each command methods.

**Before:**

```go
func newRootCmd() *cobra.Command {
         rootCmd.AddCommand(newInitCmd())

// ------------------------------------

type initCmd struct {
	meta
}
func newInitCmd() *cobra.Command {
	c := &initCmd{}
	initCmd := &cobra.Command{
                 // ...
		RunE: func(cmd *cobra.Command, args []string) error {
			if err := c.meta.init(args); err != nil {
				return err
			}
```
**After:**
```go
func Execute() error {
         // ...
	meta := metaCmd{}
	if err := meta.init(); err != nil {
		return errors.Wrap(err, "failed to initialize afx")
	}
	return newRootCmd(meta).Execute()
}

func newRootCmd(m metaCmd) *cobra.Command {
         // ...
	rootCmd.AddCommand(
		m.newInitCmd(),
        )

// ------------------------------------

type initCmd struct {
	metaCmd
}
func (m metaCmd) newInitCmd() *cobra.Command {
        c := &initCmd{metaCmd: m}
	return &cobra.Command{
		Run: func(cmd *cobra.Command, args []string) {
                     // ...
		},
	}
```

## WHY

By taking the `meta.init()` method out of each commands, afx can become to get meta information at root command level. `meta` has a lot of information to run afx command, so these data can be used before running each command. For example, `state` data. It can be passed to each command as its valid args.

Thanks to this, each command completion feature will be more powerful. Other benefits also will be appeared soon.