### PR TITLE
Add error handling in build

### DIFF
--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -167,9 +167,11 @@ func (c Command) build(pkg Package) error {
 	p.ParseBacktick = true
 	p.Dir = pkg.GetHome()
 
+	var errs errors.Errors
 	for _, step := range c.Build.Steps {
 		args, err := p.Parse(step)
 		if err != nil {
+			errs.Append(err)
 			continue
 		}
 		var stdin io.Reader = os.Stdin
@@ -192,10 +194,13 @@ func (c Command) build(pkg Package) error {
 		log.Printf("[INFO] cd %s\n", pkg.GetHome())
 		cmd.Dir = pkg.GetHome()
 		if err := cmd.Run(); err != nil {
-			return errors.New(stderr.String())
+			errs.Append(err)
+			if stderr.String() != "" {
+				errs.Append(errors.New(stderr.String()))
+			}
 		}
 	}
-	return nil
+	return errs.ErrorOrNil()
 }
 
 // Install is


### PR DESCRIPTION
## WHAT

Add error handling with multiple errors in build step

## WHY

I found this kinda case:

<img width="600" alt="" src="https://user-images.githubusercontent.com/4442708/156210435-34906fb2-cd1e-400f-8c34-f83fefad8a2a.png">

It's not friendly error message so much.