### PR TITLE
Fix Installed() method behavior on plugin install

### DIFF
--- a/pkg/config/plugin.go
+++ b/pkg/config/plugin.go
@@ -25,9 +25,18 @@ type Plugin struct {
 func (p *Plugin) UnmarshalYAML(b []byte) error {
 	type alias Plugin
 
+	// Unlike UnmarshalJSON, all of fields in struct should be listed here...
+	// http://choly.ca/post/go-json-marshalling/
+	// https://go.dev/play/p/rozEOsAYHPe // JSON works but replacing json with yaml then not working
+	// https://stackoverflow.com/questions/48674624/unmarshal-a-yaml-to-a-struct-with-unexpected-fields-in-go
+	// https://go.dev/play/p/XZg7tEPGXna // other YAML case
 	tmp := struct {
 		*alias
-		Sources []string `yaml:"sources"`
+		Sources        []string          `yaml:"sources" validate:"required"`
+		Env            map[string]string `yaml:"env"`
+		Snippet        string            `yaml:"snippet"`
+		SnippetPrepare string            `yaml:"snippet-prepare"`
+		If             string            `yaml:"if"`
 	}{
 		alias: (*alias)(p),
 	}
@@ -40,7 +49,12 @@ func (p *Plugin) UnmarshalYAML(b []byte) error {
 	for _, source := range tmp.Sources {
 		sources = append(sources, expandTilda(os.ExpandEnv(source)))
 	}
+
 	p.Sources = sources
+	p.Env = tmp.Env
+	p.Snippet = tmp.Snippet
+	p.SnippetPrepare = tmp.SnippetPrepare
+	p.If = tmp.If
 
 	return nil
 }

--- a/pkg/config/plugin.go
+++ b/pkg/config/plugin.go
@@ -45,12 +45,12 @@ func (p *Plugin) UnmarshalYAML(b []byte) error {
 	return nil
 }
 
-// Installed returns true ...
+// Installed returns true if sources exist at least one or more
 func (p Plugin) Installed(pkg Package) bool {
 	return len(p.GetSources(pkg)) > 0
 }
 
-// Install is
+// Install runs nothing on plugin installation
 func (p Plugin) Install(pkg Package) error {
 	return nil
 }
@@ -100,12 +100,7 @@ func (p Plugin) Init(pkg Package) error {
 		fmt.Printf("%s\n", s)
 	}
 
-	sources := p.GetSources(pkg)
-	if len(sources) == 0 {
-		return fmt.Errorf("%s: failed to get sources", pkg.GetName())
-	}
-
-	for _, src := range sources {
+	for _, src := range p.GetSources(pkg) {
 		fmt.Printf("source %s\n", src)
 	}
 


### PR DESCRIPTION
## WHAT

Fix `Installed()` logic on plugin installation

## WHY

`plugin.Installed()` behavior was still kept as old implementations was.
So changed to use GetSources (it's considering glob) and add tilde consideration

ref: https://github.com/b4b4r07/afx/issues/32