### PR TITLE
Fix `http.Installed()` behavior

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,6 +81,7 @@ func parse(cfg Config) []Package {
 		pkgs = append(pkgs, pkg)
 	}
 	for _, pkg := range cfg.HTTP {
+		pkg.ParseURL()
 		pkgs = append(pkgs, pkg)
 	}
 


### PR DESCRIPTION
## WHAT

Run URL templating just after parsing YAML file and reuse it in all places in `http` package to get valid URL even if template variables are used in URL field

## WHY


`http` package allows to use template variables in URL field but `GetHome()` is also referring c.URL but it's not templated so `Installed()` is failed