### PR TITLE
Fix bug when state.json does not exist

### DIFF
--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -130,7 +130,7 @@ func (m *metaCmd) init() error {
 
 	s, err := state.Open(filepath.Join(root, "state.json"), resourcers)
 	if err != nil {
-		return errors.Wrap(err, "faield to open state file")
+		return errors.Wrap(err, "failed to open state file")
 	}
 	m.state = s
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -87,7 +86,8 @@ var exists = func(path string) bool {
 var ReadStateFile = func(filename string) ([]byte, error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, pathError(err)
+		// return empty json contents if state.json does not exist
+		return []byte(`{}`), nil
 	}
 	defer f.Close()
 
@@ -101,17 +101,6 @@ var ReadStateFile = func(filename string) ([]byte, error) {
 
 var SaveStateFile = func(filename string) (io.Writer, error) {
 	return os.Create(filename)
-}
-
-func pathError(err error) error {
-	var pathError *os.PathError
-	if errors.As(err, &pathError) && errors.Is(pathError.Err, syscall.ENOTDIR) {
-		if p := findRegularFile(pathError.Path); p != "" {
-			return fmt.Errorf("remove or rename regular file `%s` (must be a directory)", p)
-		}
-
-	}
-	return err
 }
 
 func findRegularFile(p string) string {


### PR DESCRIPTION
## WHAT

Do not return error (file not exists) when state.json doesn't exist (just return empty json contents to continue to read state file)

## WHY

Fix #36 