### PR TITLE
Support gz case (decompress)

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/b4b4r07/afx/pkg/config"
 	"github.com/b4b4r07/afx/pkg/errors"
 	"github.com/b4b4r07/afx/pkg/helpers/templates"
+	"github.com/b4b4r07/afx/pkg/logging"
 	"github.com/b4b4r07/afx/pkg/state"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -119,8 +120,10 @@ func (c *installCmd) run(pkgs []config.Package) error {
 			case nil:
 				c.state.Add(pkg)
 			default:
-				log.Printf("[DEBUG] uninstall %q because installation failed", pkg.GetName())
-				pkg.Uninstall(ctx)
+				if !logging.IsSet() {
+					log.Printf("[DEBUG] uninstall %q because installation failed", pkg.GetName())
+					pkg.Uninstall(ctx)
+				}
 			}
 			select {
 			case results <- installResult{Package: pkg, Error: err}:


### PR DESCRIPTION
## WHAT

Support an archive file having `.gz` file extension.

## WHY

#45 (In this issue, having `format` field is suggested but it's fixed by supporting it in a fundamental way in this PR)

