### PR TITLE
Fix self-update #47

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -204,7 +204,7 @@ func (r *Release) filterAssets() (Asset, error) {
 			expr := ""
 			switch runtime.GOARCH {
 			case "amd64":
-				expr += ".*(amd64|64).*"
+				expr += ".*(amd64|x86.64).*"
 			case "386":
 				expr += ".*(386|86).*"
 			}


### PR DESCRIPTION
If GOARCH is amd64, expr should contain `x86.64` instead of `64`, because `arm64` will matches this regex.
