### PR TITLE
Support gh extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Full document is here: [AFX](https://babarot.me/afx/)
 
 - Allows to manage various packages types:
   - GitHub / GitHub Release / Gist / HTTP (web) / Local
+  - [gh extensions](https://github.com/topics/gh-extension)
 - Manages as CLI commands, shell plugins or both
 - Easy to install/update/uninstall
 - Easy to configure with YAML

--- a/docs/configuration/package/github.md
+++ b/docs/configuration/package/github.md
@@ -87,6 +87,28 @@ number | `0` (all commits)
 
 Limit fetching to the specified number of commits from the tip of each remote branch history. If fetching to a shallow repository, specify 1 or more number, deepen or shorten the history to the specified number of commits.
 
+### as
+
+Type | Default
+---|---
+string | `""`
+
+Available arguments:
+
+- gh-extension
+
+=== "gh-extension"
+
+    Install a package as [gh extension](https://github.blog/2023-01-13-new-github-cli-extension-tools/). Officially gh extensions can be installed with `gh extension install owern/repo` command ([guide](https://cli.github.com/manual/gh_extension_install)) but it's difficult to manage what we downloaded as code. In afx, by handling them as the same as other packages, it allows us to codenize them.
+
+    ```yaml
+    - name: dlvhdr/gh-dash
+      description: A beautiful CLI dashboard for GitHub
+      owner: dlvhdr
+      repo: gh-dash
+      as: gh-extension
+    ```
+
 ### release.name
 
 Type | Default

--- a/docs/configuration/package/github.md
+++ b/docs/configuration/package/github.md
@@ -102,6 +102,7 @@ Change the installation behavior of the packages based on specified package type
     Key | Type | Default
     ---|---|---
     name | string | (required)
+    tag | string | `latest`
     rename-to | string | `""`
 
     ```yaml
@@ -112,6 +113,7 @@ Change the installation behavior of the packages based on specified package type
       as:
         gh-extension:
           name: gh-markdown-preview
+          tag: v1.4.0
           rename-to: gh-md    # markdown-preview is long so rename it to shorten.
     ```
 

--- a/docs/configuration/package/github.md
+++ b/docs/configuration/package/github.md
@@ -89,24 +89,30 @@ Limit fetching to the specified number of commits from the tip of each remote br
 
 ### as
 
-Type | Default
----|---
-string | `""`
+Key | Type | Default
+---|---|---
+gh-extension | Object | `null`
 
-Available arguments:
-
-- gh-extension
+Change the installation behavior of the packages based on specified package type. In current afx, all packages are based on where it's hosted e.g. `github`. Almost all cases are not problem on that but some package types (such as "brew" or "gh extension") will be able to do more easily if there is a dedicated parameters to install the packages. In this `as` section, it expands more this installation method. Some of package types (especially "brew") will be coming soon in near future.
 
 === "gh-extension"
 
     Install a package as [gh extension](https://github.blog/2023-01-13-new-github-cli-extension-tools/). Officially gh extensions can be installed with `gh extension install owern/repo` command ([guide](https://cli.github.com/manual/gh_extension_install)) but it's difficult to manage what we downloaded as code. In afx, by handling them as the same as other packages, it allows us to codenize them.
 
+    Key | Type | Default
+    ---|---|---
+    name | string | (required)
+    rename-to | string | `""`
+
     ```yaml
-    - name: dlvhdr/gh-dash
-      description: A beautiful CLI dashboard for GitHub
-      owner: dlvhdr
-      repo: gh-dash
-      as: gh-extension
+    - name: yusukebe/gh-markdown-preview
+      description: GitHub CLI extension to preview Markdown looks like GitHub.
+      owner: yusukebe
+      repo: gh-markdown-preview
+      as:
+        gh-extension:
+          name: gh-markdown-preview
+          rename-to: gh-md    # markdown-preview is long so rename it to shorten.
     ```
 
 ### release.name

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,3 +29,5 @@ Flags:
 
 Use "afx [command] --help" for more information about a command.
 ```
+
+![](https://user-images.githubusercontent.com/4442708/224565945-2c09b729-82b7-4829-9cbc-e247b401b689.gif)

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.6.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
+	gopkg.in/yaml.v2 v2.2.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,7 @@ gopkg.in/src-d/go-git.v4 v4.13.1 h1:SRtFyV8Kxc0UP7aCHcijOMQGPxHSmMOPrzulQWolkYE=
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/b4b4r07/afx/pkg/dependency"
-	"github.com/b4b4r07/afx/pkg/errors"
 	"github.com/b4b4r07/afx/pkg/state"
 	"github.com/go-playground/validator/v10"
 	"github.com/goccy/go-yaml"
@@ -98,7 +97,7 @@ func (c Config) Parse() ([]Package, error) {
 func visitYAML(files *[]string) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "%s: failed to visit", path)
+			return fmt.Errorf("%w: %s: failed to visit", err, path)
 		}
 		switch filepath.Ext(path) {
 		case ".yaml", ".yml":
@@ -178,7 +177,7 @@ func Sort(given []Package) ([]Package, error) {
 
 	resolved, err := dependency.Resolve(graph)
 	if err != nil {
-		return pkgs, errors.Wrap(err, "failed to resolve dependency graph")
+		return pkgs, fmt.Errorf("%w: failed to resolve dependency graph", err)
 	}
 
 	for _, node := range resolved {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,7 @@ func Read(path string) (Config, error) {
 	defer f.Close()
 
 	validate := validator.New()
+	validate.RegisterValidation("gh-extension", ValidateGHExtension)
 	d := yaml.NewDecoder(
 		bufio.NewReader(f),
 		yaml.DisallowUnknownField(),
@@ -243,6 +244,11 @@ func getResource(pkg Package) state.Resource {
 		id = fmt.Sprintf("github.com/%s/%s", pkg.Owner, pkg.Repo)
 		if pkg.HasReleaseBlock() {
 			id = fmt.Sprintf("github.com/release/%s/%s", pkg.Owner, pkg.Repo)
+		}
+		if pkg.IsGHExtension() {
+			ty = "GitHub (gh extension)"
+			gh := pkg.As.GHExtension
+			paths = append(paths, gh.GetHome())
 		}
 	case Gist:
 		ty = "Gist"

--- a/pkg/config/github.go
+++ b/pkg/config/github.go
@@ -248,6 +248,7 @@ func (c GitHub) InstallFromRelease(ctx context.Context, owner, repo, tag string)
 
 	release, err := github.NewRelease(
 		ctx, owner, repo, tag,
+		github.WithOverwrite(),
 		github.WithWorkdir(c.GetHome()),
 		github.WithFilter(func(filename string) github.FilterFunc {
 			if filename == "" {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -390,10 +390,16 @@ func (r *Release) Install(to string) error {
 	})
 }
 
-func HasRelease(httpClient *http.Client, owner, repo string) (bool, error) {
+func HasRelease(httpClient *http.Client, owner, repo, tag string) (bool, error) {
 	// https://github.com/cli/cli/blob/9596fd5368cdbd30d08555266890a2312e22eba9/pkg/cmd/extension/http.go#L110
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
-	req, err := http.NewRequest("GET", url, nil)
+	releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases", owner, repo)
+	switch tag {
+	case "latest", "":
+		releaseURL += "/latest"
+	default:
+		releaseURL += fmt.Sprintf("/tags/%s", tag)
+	}
+	req, err := http.NewRequest("GET", releaseURL, nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -376,3 +376,19 @@ func (r *Release) Install(to string) error {
 		TargetPath: to,
 	})
 }
+
+func HasRelease(httpClient *http.Client, owner, repo string) (bool, error) {
+	// https://github.com/cli/cli/blob/9596fd5368cdbd30d08555266890a2312e22eba9/pkg/cmd/extension/http.go#L110
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 299, nil
+}


### PR DESCRIPTION
## WHAT

Support gh extension

- https://github.com/cli/cli
- https://docs.github.com/en/github-cli/github-cli/using-github-cli-extensions
- https://github.blog/2023-01-13-new-github-cli-extension-tools/

## WHY

Officially gh command has a sub command to install its extenstions: `gh extension install owern/repo` command ([guide](https://cli.github.com/manual/gh_extension_install)). But it's difficult to manage what we downloaded as code. In afx, by handling them as the same as other packages, it allows us to codenize them.