### PR TITLE
Create ~/.config/afx if not exist

### DIFF
--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -48,10 +48,10 @@ func (m *metaCmd) init() error {
 	cfgRoot := filepath.Join(os.Getenv("HOME"), ".config", "afx")
 	cache := filepath.Join(root, "cache.json")
 
-    err := config.CreateDirIfNotExist(cfgRoot)
-    if err != nil {
-        return errors.Wrapf(err, "%s: failed to create dir", cfgRoot)
-    }
+	err := config.CreateDirIfNotExist(cfgRoot)
+	if err != nil {
+		return errors.Wrapf(err, "%s: failed to create dir", cfgRoot)
+	}
 	files, err := config.WalkDir(cfgRoot)
 	if err != nil {
 		return errors.Wrapf(err, "%s: failed to walk dir", cfgRoot)

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -48,6 +48,10 @@ func (m *metaCmd) init() error {
 	cfgRoot := filepath.Join(os.Getenv("HOME"), ".config", "afx")
 	cache := filepath.Join(root, "cache.json")
 
+    err := config.CreateDirIfNotExist(cfgRoot)
+    if err != nil {
+        return errors.Wrapf(err, "%s: failed to create dir", cfgRoot)
+    }
 	files, err := config.WalkDir(cfgRoot)
 	if err != nil {
 		return errors.Wrapf(err, "%s: failed to walk dir", cfgRoot)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -113,8 +113,8 @@ func CreateDirIfNotExist(path string) error {
 	if os.IsNotExist(err) {
 		return os.MkdirAll(path, 0755)
 	} else if err != nil {
-        return err
-    }
+		return err
+	}
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,16 @@ func visitYAML(files *[]string) filepath.WalkFunc {
 	}
 }
 
+func CreateDirIfNotExist(path string) error {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(path, 0755)
+	} else if err != nil {
+        return err
+    }
+	return nil
+}
+
 func resolvePath(path string) (string, bool, error) {
 	fi, err := os.Lstat(path)
 	if err != nil {


### PR DESCRIPTION
Now, the `afx` command exits with error if `~/.config/afx` doesn't exist.
This means [install script](https://github.com/b4b4r07/afx/blob/main/hack/README.md) always finishes error, and this isn't natural.

I created pull-request to create the directory on command execution.