### PR TITLE
fix: resolve issue with unrecognized symblic links

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,14 +124,21 @@ func resolvePath(path string) (string, bool, error) {
 		return path, false, err
 	}
 
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		path, err = os.Readlink(path)
+		if err != nil {
+			return path, false, err
+		}
+		fi, err = os.Lstat(path)
+		if err != nil {
+			return path, false, err
+		}
+	}
+
 	isDir := fi.IsDir()
 
 	if filepath.IsAbs(path) {
 		return path, isDir, nil
-	}
-
-	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-		path, err = os.Readlink(path)
 	}
 
 	return path, isDir, err


### PR DESCRIPTION
fixes #51 

This PR fixes an issue that occurs when using symlinks in the afx configuration directory.

I'm not familiar with Go, so sorry if I messed up.