### PR TITLE
Add GitHub Labels automation and Release Changelog categories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+area/docs:
+  - changed-files:
+    - any-glob-to-any-file: 'docs/**'
+
+changelog/skip:
+  - all:
+    - changed-files:
+      - all-globs-to-all-files:
+        - '!**/*.go'
+        - '!docs/**'

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,57 @@
+# tag management - used by tagpr management
+- name: tagpr
+  description: Used by tagpr for managing the release
+  color: ededed
+- name: tagpr:minor
+  description: Used by tagpr for managing the release
+  color: ededed
+- name: tagpr:major
+  description: Used by tagpr for managing the release
+  color: ededed
+- name: changelog/skip
+  description: Used in case of no need to update changelog
+  color: ededed
+- name: changelog/missing
+  description: Changelog entry is missing; review before merging.
+  color: ededed
+
+# kind/ - the type of issue
+- name: kind/bug
+  description: A bug; unintended behavior
+  color: 425df5
+- name: kind/feature
+  description: A feature request; new or enhanced behavior
+  color: 425df5
+- name: kind/deprecation
+  description: Related to a feature or part of code being deprecated.
+  color: 425df5
+- name: kind/cleanup
+  description: Categorizes issue or PR as related to cleaning up code, issues, etc.
+  color: 425df5
+- name: kind/breaking-change
+  description: Denotes a PR that introduces potentially breaking changes that require user action.
+  color: 425df5
+
+# area/
+- name: area/docs
+  description: Changes related to the project's documentation
+  color: 7ed6df
+
+# platform/
+- name: platform/windows
+  description: Windows operating system related issues and features.
+  color: f8e58c
+- name: platform/linux
+  description: Linux operating system related issues and features.
+  color: f8e58c
+- name: platform/macos
+  description: macOS operating system related issues and features.
+  color: f8e58c
+
+# release/ - which version to be released
+- name: release/major
+  description: Indicates major version to bump up next when creating release PR.
+  color: 1dd1a1
+- name: release/minor
+  description: Indicates minor version to bump up next when creating release PR.
+  color: 1dd1a1

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,26 @@ changelog:
   exclude:
     labels:
       - tagpr
+      - changelog/skip
+  categories:
+    - title: Breaking Changes
+      labels:
+        - kind/breaking-change
+    - title: New Features
+      labels:
+        - kind/feature
+    - title: Bug fixes
+      labels:
+        - kind/bug
+    - title: Deprecated features
+      labels:
+        - kind/deprecation
+    - title: Refactorings
+      labels:
+        - kind/cleanup
+    - title: Documentation
+      labels:
+        - area/docs
+    - title: Others
+      labels:
+        - "*"

--- a/.github/workflows/add_labels.yaml
+++ b/.github/workflows/add_labels.yaml
@@ -1,0 +1,18 @@
+name: Labels
+on: pull_request
+
+jobs:
+  triage:
+    if: github.event.pull_request.head.repo.fork == false
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,5 +1,17 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go.yaml'
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go.yaml'
 jobs:
   build:
     strategy:

--- a/.github/workflows/sync_labels.yaml
+++ b/.github/workflows/sync_labels.yaml
@@ -1,0 +1,27 @@
+name: Sync Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/labels.yaml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Sync labels
+        uses: EndBug/label-sync@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/labels.yaml
+          delete-other-labels: true


### PR DESCRIPTION
Introduce a comprehensive GitHub labels management system and improve the release changelog organization.

## Changes

### Label Definitions (`.github/labels.yaml`)

Define standardized labels for the repository:

- **Tag management**: `tagpr`, `tagpr:minor`, `tagpr:major`, `changelog/skip`, `changelog/missing`
- **Kind labels**: `kind/bug`, `kind/feature`, `kind/deprecation`, `kind/cleanup`, `kind/breaking-change`
- **Area labels**: `area/docs`
- **Platform labels**: `platform/windows`, `platform/linux`, `platform/macos`
- **Release labels**: `release/major`, `release/minor`

### Auto-labeling PRs (`.github/labeler.yml`)

Configure automatic label assignment based on changed files:

- `area/docs`: Applied when files in `docs/**` are modified
- `changelog/skip`: Applied when no `.go` files or docs are changed

### Workflows

**`add_labels.yaml`**:
- Trigger on pull requests
- Automatically apply labels based on `labeler.yml` rules

**`sync_labels.yaml`**:
- Trigger on push to main when `.github/labels.yaml` changes
- Sync repository labels with the config file
- Delete labels not defined in the config

### Release Changelog Categories (`.github/release.yml`)

Organize release notes into categories:

- Breaking Changes
- New Features
- Bug fixes
- Deprecated features
- Refactorings
- Documentation
- Others

Exclude PRs with `changelog/skip` label from release notes.
