### PR TITLE
Drop Windows support, rename pkg to manager, add state file lock

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/*
 afx
 *.swp
 vendor
+docs/temp_*
+*.lock

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     goarch:
       - amd64
@@ -33,9 +32,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    format_overrides:
-      - goos: windows
-        formats: ["zip"]
 
 changelog:
   sort: asc

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/babarot/afx/internal/helpers/templates"
-	afxpkg "github.com/babarot/afx/internal/pkg"
+	manager "github.com/babarot/afx/internal/manager"
 	"github.com/babarot/afx/internal/runner"
 	"github.com/babarot/afx/internal/state"
 )
@@ -73,7 +73,7 @@ func (m metaCmd) newCheckCmd() *cobra.Command {
 
 			pkgs := m.GetPackages(resources)
 			m.env.AskWhen(map[string]bool{
-				"GITHUB_TOKEN": afxpkg.HasGitHubReleaseBlock(pkgs),
+				"GITHUB_TOKEN": manager.HasGitHubReleaseBlock(pkgs),
 			})
 
 			return c.run(pkgs)
@@ -86,7 +86,7 @@ func (m metaCmd) newCheckCmd() *cobra.Command {
 	return checkCmd
 }
 
-func (c *checkCmd) run(pkgs []afxpkg.Package) error {
+func (c *checkCmd) run(pkgs []manager.Package) error {
 	log.Printf("[DEBUG] (check): start to run each pkg.Check()")
 
 	runnerPkgs := make([]runner.Package, len(pkgs))
@@ -95,7 +95,7 @@ func (c *checkCmd) run(pkgs []afxpkg.Package) error {
 	}
 
 	err := runner.Execute(runnerPkgs, func(p runner.Package) runner.TaskFunc {
-		pkg, _ := p.(afxpkg.Package)
+		pkg, _ := p.(manager.Package)
 		return func(ctx context.Context, completion chan<- runner.Status) error {
 			return pkg.Check(ctx, completion)
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/babarot/afx/internal/helpers/templates"
 	"github.com/babarot/afx/internal/logging"
-	afxpkg "github.com/babarot/afx/internal/pkg"
+	manager "github.com/babarot/afx/internal/manager"
 	"github.com/babarot/afx/internal/runner"
 	"github.com/babarot/afx/internal/state"
 )
@@ -74,8 +74,8 @@ func (m metaCmd) newInstallCmd() *cobra.Command {
 
 			pkgs := m.GetPackages(resources)
 			m.env.AskWhen(map[string]bool{
-				"GITHUB_TOKEN":      afxpkg.HasGitHubReleaseBlock(pkgs),
-				"AFX_SUDO_PASSWORD": afxpkg.HasSudoInCommandBuildSteps(pkgs),
+				"GITHUB_TOKEN":      manager.HasGitHubReleaseBlock(pkgs),
+				"AFX_SUDO_PASSWORD": manager.HasSudoInCommandBuildSteps(pkgs),
 			})
 
 			return c.run(pkgs)
@@ -88,7 +88,7 @@ func (m metaCmd) newInstallCmd() *cobra.Command {
 	return installCmd
 }
 
-func (c *installCmd) run(pkgs []afxpkg.Package) error {
+func (c *installCmd) run(pkgs []manager.Package) error {
 	log.Printf("[DEBUG] (install): start to run each pkg.Install()")
 
 	runnerPkgs := make([]runner.Package, len(pkgs))
@@ -97,7 +97,7 @@ func (c *installCmd) run(pkgs []afxpkg.Package) error {
 	}
 
 	err := runner.Execute(runnerPkgs, func(p runner.Package) runner.TaskFunc {
-		pkg, _ := p.(afxpkg.Package)
+		pkg, _ := p.(manager.Package)
 		return func(ctx context.Context, completion chan<- runner.Status) error {
 			err := pkg.Install(ctx, completion)
 			switch err {

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -14,7 +14,7 @@ import (
 	"github.com/babarot/afx/internal/env"
 	"github.com/babarot/afx/internal/errors"
 	"github.com/babarot/afx/internal/github"
-	afxpkg "github.com/babarot/afx/internal/pkg"
+	manager "github.com/babarot/afx/internal/manager"
 	"github.com/babarot/afx/internal/printers"
 	"github.com/babarot/afx/internal/state"
 	"github.com/babarot/afx/internal/update"
@@ -22,10 +22,10 @@ import (
 
 type metaCmd struct {
 	env      *env.Config
-	packages []afxpkg.Package
-	main     *afxpkg.Main
+	packages []manager.Package
+	main     *manager.Main
 	state    *state.State
-	configs  map[string]afxpkg.Config
+	configs  map[string]manager.Config
 
 	updateMessageChan chan *update.ReleaseInfo
 }
@@ -55,21 +55,21 @@ func (m *metaCmd) init() error {
 
 // loadConfigs reads and parses all YAML config files from the config directory.
 func (m *metaCmd) loadConfigs() error {
-	cfgRoot := afxpkg.ConfigDir()
+	cfgRoot := manager.ConfigDir()
 
-	if err := afxpkg.CreateDirIfNotExist(cfgRoot); err != nil {
+	if err := manager.CreateDirIfNotExist(cfgRoot); err != nil {
 		return errors.Wrapf(err, "%s: failed to create dir", cfgRoot)
 	}
-	files, err := afxpkg.WalkDir(cfgRoot)
+	files, err := manager.WalkDir(cfgRoot)
 	if err != nil {
 		return errors.Wrapf(err, "%s: failed to walk dir", cfgRoot)
 	}
 
-	var pkgs []afxpkg.Package
-	app := &afxpkg.DefaultMain
-	m.configs = map[string]afxpkg.Config{}
+	var pkgs []manager.Package
+	app := &manager.DefaultMain
+	m.configs = map[string]manager.Config{}
 	for _, file := range files {
-		cfg, err := afxpkg.Read(file)
+		cfg, err := manager.Read(file)
 		if err != nil {
 			return errors.Wrapf(err, "%s: failed to read config", file)
 		}
@@ -91,10 +91,10 @@ func (m *metaCmd) loadConfigs() error {
 
 // initPackages validates and sorts packages by dependency order.
 func (m *metaCmd) initPackages() error {
-	if err := afxpkg.Validate(m.packages); err != nil {
+	if err := manager.Validate(m.packages); err != nil {
 		return errors.Wrap(err, "failed to validate packages")
 	}
-	sorted, err := afxpkg.Sort(m.packages)
+	sorted, err := manager.Sort(m.packages)
 	if err != nil {
 		return errors.Wrap(err, "failed to resolve dependencies between packages")
 	}
@@ -104,8 +104,8 @@ func (m *metaCmd) initPackages() error {
 
 // initEnv sets up environment variables and creates required directories.
 func (m *metaCmd) initEnv() error {
-	root := afxpkg.DataDir()
-	cfgRoot := afxpkg.ConfigDir()
+	root := manager.DataDir()
+	cfgRoot := manager.ConfigDir()
 	cache := filepath.Join(root, "cache.json")
 
 	m.env = env.New(cache)
@@ -113,18 +113,18 @@ func (m *metaCmd) initEnv() error {
 		"AFX_CONFIG_PATH":  env.Variable{Value: cfgRoot},
 		"AFX_LOG":          env.Variable{},
 		"AFX_LOG_PATH":     env.Variable{},
-		"AFX_COMMAND_PATH": env.Variable{Default: afxpkg.BinDir()},
+		"AFX_COMMAND_PATH": env.Variable{Default: manager.BinDir()},
 		"AFX_SHELL":        env.Variable{Default: m.main.Shell},
 		"AFX_SUDO_PASSWORD": env.Variable{
 			Input: env.Input{
-				When:    afxpkg.HasSudoInCommandBuildSteps(m.packages),
+				When:    manager.HasSudoInCommandBuildSteps(m.packages),
 				Message: "Please enter sudo command password",
 				Help:    "Some packages build steps requires sudo command",
 			},
 		},
 		"GITHUB_TOKEN": env.Variable{
 			Input: env.Input{
-				When:    afxpkg.HasGitHubReleaseBlock(m.packages),
+				When:    manager.HasGitHubReleaseBlock(m.packages),
 				Message: "Please type your GITHUB_TOKEN",
 				Help:    "To fetch GitHub Releases, GitHub token is required",
 			},
@@ -144,7 +144,7 @@ func (m *metaCmd) initEnv() error {
 
 // initState opens the state file and logs the current state summary.
 func (m *metaCmd) initState() error {
-	root := afxpkg.DataDir()
+	root := manager.DataDir()
 
 	resourcers := make([]state.Resourcer, len(m.packages))
 	for i, pkg := range m.packages {
@@ -251,11 +251,11 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 		return nil, nil
 	}
 	client := github.NewClient()
-	stateFilePath := filepath.Join(afxpkg.DataDir(), "version.json")
+	stateFilePath := filepath.Join(manager.DataDir(), "version.json")
 	return update.CheckForUpdate(client, stateFilePath, Repository, Version)
 }
 
-func (m metaCmd) GetPackage(resource state.Resource) afxpkg.Package {
+func (m metaCmd) GetPackage(resource state.Resource) manager.Package {
 	for _, pkg := range m.packages {
 		if pkg.GetName() == resource.Name {
 			return pkg
@@ -264,16 +264,16 @@ func (m metaCmd) GetPackage(resource state.Resource) afxpkg.Package {
 	return nil
 }
 
-func (m metaCmd) GetPackages(resources []state.Resource) []afxpkg.Package {
-	var pkgs []afxpkg.Package
+func (m metaCmd) GetPackages(resources []state.Resource) []manager.Package {
+	var pkgs []manager.Package
 	for _, resource := range resources {
 		pkgs = append(pkgs, m.GetPackage(resource))
 	}
 	return pkgs
 }
 
-func (m metaCmd) GetConfig() afxpkg.Config {
-	var all afxpkg.Config
+func (m metaCmd) GetConfig() manager.Config {
+	var all manager.Config
 	for _, cfg := range m.configs {
 		if cfg.Main != nil {
 			all.Main = cfg.Main

--- a/cmd/meta_test.go
+++ b/cmd/meta_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	afxpkg "github.com/babarot/afx/internal/pkg"
+	manager "github.com/babarot/afx/internal/manager"
 	"github.com/babarot/afx/internal/state"
 )
 
@@ -16,9 +16,9 @@ func init() {
 
 func TestGetPackage_found(t *testing.T) {
 	m := metaCmd{
-		packages: []afxpkg.Package{
-			&afxpkg.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
-			&afxpkg.GitHub{Name: "tool-b", Owner: "owner", Repo: "tool-b"},
+		packages: []manager.Package{
+			&manager.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
+			&manager.GitHub{Name: "tool-b", Owner: "owner", Repo: "tool-b"},
 		},
 	}
 
@@ -35,8 +35,8 @@ func TestGetPackage_found(t *testing.T) {
 
 func TestGetPackage_notFound(t *testing.T) {
 	m := metaCmd{
-		packages: []afxpkg.Package{
-			&afxpkg.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
+		packages: []manager.Package{
+			&manager.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
 		},
 	}
 
@@ -50,10 +50,10 @@ func TestGetPackage_notFound(t *testing.T) {
 
 func TestGetPackages(t *testing.T) {
 	m := metaCmd{
-		packages: []afxpkg.Package{
-			&afxpkg.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
-			&afxpkg.GitHub{Name: "tool-b", Owner: "owner", Repo: "tool-b"},
-			&afxpkg.GitHub{Name: "tool-c", Owner: "owner", Repo: "tool-c"},
+		packages: []manager.Package{
+			&manager.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
+			&manager.GitHub{Name: "tool-b", Owner: "owner", Repo: "tool-b"},
+			&manager.GitHub{Name: "tool-c", Owner: "owner", Repo: "tool-c"},
 		},
 	}
 
@@ -75,25 +75,25 @@ func TestGetPackages(t *testing.T) {
 }
 
 func TestGetConfig_mergesAll(t *testing.T) {
-	main := &afxpkg.Main{Shell: "zsh"}
+	main := &manager.Main{Shell: "zsh"}
 
 	m := metaCmd{
-		configs: map[string]afxpkg.Config{
+		configs: map[string]manager.Config{
 			"file1.yaml": {
 				Main: main,
-				GitHub: []*afxpkg.GitHub{
+				GitHub: []*manager.GitHub{
 					{Name: "gh1", Owner: "o", Repo: "r1"},
 					{Name: "gh2", Owner: "o", Repo: "r2"},
 				},
-				Gist: []*afxpkg.Gist{
+				Gist: []*manager.Gist{
 					{Name: "gist1", Owner: "o", ID: "id1"},
 				},
 			},
 			"file2.yaml": {
-				GitHub: []*afxpkg.GitHub{
+				GitHub: []*manager.GitHub{
 					{Name: "gh3", Owner: "o", Repo: "r3"},
 				},
-				Gist: []*afxpkg.Gist{
+				Gist: []*manager.Gist{
 					{Name: "gist2", Owner: "o", ID: "id2"},
 				},
 			},
@@ -121,9 +121,9 @@ func TestGetConfig_mergesAll(t *testing.T) {
 
 func TestGetConfig_noMain(t *testing.T) {
 	m := metaCmd{
-		configs: map[string]afxpkg.Config{
+		configs: map[string]manager.Config{
 			"file1.yaml": {
-				GitHub: []*afxpkg.GitHub{
+				GitHub: []*manager.GitHub{
 					{Name: "gh1", Owner: "o", Repo: "r1"},
 				},
 			},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,6 +95,9 @@ func Execute() error {
 	if err := meta.init(); err != nil {
 		return errors.Wrap(err, "failed to initialize afx")
 	}
+	if meta.state != nil {
+		defer meta.state.Close()
+	}
 
 	defer log.Printf("[INFO] root command execution finished")
 	return newRootCmd(meta).Execute()

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/babarot/afx/internal/helpers/templates"
-	afxpkg "github.com/babarot/afx/internal/pkg"
+	manager "github.com/babarot/afx/internal/manager"
 	"github.com/babarot/afx/internal/runner"
 	"github.com/babarot/afx/internal/state"
 )
@@ -74,8 +74,8 @@ func (m metaCmd) newUpdateCmd() *cobra.Command {
 
 			pkgs := m.GetPackages(resources)
 			m.env.AskWhen(map[string]bool{
-				"GITHUB_TOKEN":      afxpkg.HasGitHubReleaseBlock(pkgs),
-				"AFX_SUDO_PASSWORD": afxpkg.HasSudoInCommandBuildSteps(pkgs),
+				"GITHUB_TOKEN":      manager.HasGitHubReleaseBlock(pkgs),
+				"AFX_SUDO_PASSWORD": manager.HasSudoInCommandBuildSteps(pkgs),
 			})
 
 			return c.run(pkgs)
@@ -88,7 +88,7 @@ func (m metaCmd) newUpdateCmd() *cobra.Command {
 	return updateCmd
 }
 
-func (c *updateCmd) run(pkgs []afxpkg.Package) error {
+func (c *updateCmd) run(pkgs []manager.Package) error {
 	log.Printf("[DEBUG] (update): start to run each pkg.Install()")
 
 	runnerPkgs := make([]runner.Package, len(pkgs))
@@ -97,7 +97,7 @@ func (c *updateCmd) run(pkgs []afxpkg.Package) error {
 	}
 
 	err := runner.Execute(runnerPkgs, func(p runner.Package) runner.TaskFunc {
-		pkg, _ := p.(afxpkg.Package)
+		pkg, _ := p.(manager.Package)
 		return func(ctx context.Context, completion chan<- runner.Status) error {
 			home := pkg.GetHome()
 			backup := home + ".bak"

--- a/internal/helpers/path/path.go
+++ b/internal/helpers/path/path.go
@@ -2,8 +2,6 @@ package path
 
 import (
 	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -13,17 +11,7 @@ func ExpandTilda(path string) string {
 		return path
 	}
 
-	home := ""
-	switch runtime.GOOS {
-	case "windows":
-		home = filepath.Join(os.Getenv("HomeDrive"), os.Getenv("HomePath"))
-		if home == "" {
-			home = os.Getenv("UserProfile")
-		}
-	default:
-		home = os.Getenv("HOME")
-	}
-
+	home := os.Getenv("HOME")
 	if home == "" {
 		return path
 	}

--- a/internal/helpers/path/path_test.go
+++ b/internal/helpers/path/path_test.go
@@ -1,14 +1,10 @@
 package path
 
 import (
-	"runtime"
 	"testing"
 )
 
 func TestExpandTilda(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("ExpandTilda uses HOME on Unix; skipping on Windows")
-	}
 
 	tests := map[string]struct {
 		input string

--- a/internal/helpers/shell/shell.go
+++ b/internal/helpers/shell/shell.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"runtime"
 )
 
 // Shell represents shell command
@@ -41,12 +40,7 @@ func (s Shell) Run(ctx context.Context) error {
 	for _, arg := range s.Args {
 		command += " " + arg
 	}
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(ctx, "cmd", "/c", command)
-	} else {
-		cmd = exec.CommandContext(ctx, "sh", "-c", command)
-	}
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Stderr = s.Stderr
 	cmd.Stdout = s.Stdout
 	cmd.Stdin = s.Stdin

--- a/internal/helpers/shell/shell_test.go
+++ b/internal/helpers/shell/shell_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"os"
-	"runtime"
 	"testing"
 )
 
@@ -45,10 +44,6 @@ func TestNew_noArgs(t *testing.T) {
 }
 
 func TestShell_Run_echo(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
 	var stdout bytes.Buffer
 	s := Shell{
 		Stdin:   &bytes.Buffer{},
@@ -71,10 +66,6 @@ func TestShell_Run_echo(t *testing.T) {
 }
 
 func TestShell_Run_withEnv(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
 	var stdout bytes.Buffer
 	s := Shell{
 		Stdin:   &bytes.Buffer{},
@@ -92,10 +83,6 @@ func TestShell_Run_withEnv(t *testing.T) {
 }
 
 func TestShell_Run_withDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
 	var stdout bytes.Buffer
 	dir := t.TempDir()
 	s := Shell{
@@ -129,10 +116,6 @@ func TestShell_Run_invalidCommand(t *testing.T) {
 }
 
 func TestShell_Run_contextCancel(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
@@ -152,10 +135,6 @@ func TestShell_Run_contextCancel(t *testing.T) {
 }
 
 func TestRunCommand(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
 	err := RunCommand("true")
 	if err != nil {
 		t.Fatalf("RunCommand() error: %v", err)
@@ -163,10 +142,6 @@ func TestRunCommand(t *testing.T) {
 }
 
 func TestRunCommand_failure(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
 	err := RunCommand("false")
 	if err == nil {
 		t.Error("RunCommand() expected error for failing command")

--- a/internal/manager/command.go
+++ b/internal/manager/command.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"bytes"

--- a/internal/manager/command_test.go
+++ b/internal/manager/command_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import "testing"
 

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"bufio"

--- a/internal/manager/config_test.go
+++ b/internal/manager/config_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"io"

--- a/internal/manager/gh_extension.go
+++ b/internal/manager/gh_extension.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/gist.go
+++ b/internal/manager/gist.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/github.go
+++ b/internal/manager/github.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"os"

--- a/internal/manager/github_check.go
+++ b/internal/manager/github_check.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/github_install.go
+++ b/internal/manager/github_install.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/http.go
+++ b/internal/manager/http.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/installed_test.go
+++ b/internal/manager/installed_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"os"

--- a/internal/manager/integration_test.go
+++ b/internal/manager/integration_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"io"

--- a/internal/manager/local.go
+++ b/internal/manager/local.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/package.go
+++ b/internal/manager/package.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/paths.go
+++ b/internal/manager/paths.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"os"

--- a/internal/manager/paths_test.go
+++ b/internal/manager/paths_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"testing"

--- a/internal/manager/plugin.go
+++ b/internal/manager/plugin.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"context"

--- a/internal/manager/read_test.go
+++ b/internal/manager/read_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"os"

--- a/internal/manager/resource.go
+++ b/internal/manager/resource.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"fmt"

--- a/internal/manager/resource_test.go
+++ b/internal/manager/resource_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"testing"

--- a/internal/manager/util.go
+++ b/internal/manager/util.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"log"

--- a/internal/manager/util_test.go
+++ b/internal/manager/util_test.go
@@ -1,4 +1,4 @@
-package pkg
+package manager
 
 import (
 	"fmt"

--- a/internal/pkg/installed_test.go
+++ b/internal/pkg/installed_test.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -43,9 +42,6 @@ func TestGist_GetHome(t *testing.T) {
 }
 
 func TestLocal_GetHome(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on Windows due to HOME handling")
-	}
 	t.Setenv("HOME", "/test/home")
 	l := Local{Directory: "~/mydir"}
 	got := l.GetHome()
@@ -64,9 +60,6 @@ func TestLocal_GetHome_absolute(t *testing.T) {
 }
 
 func TestHTTP_GetHome(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on Windows due to HOME path handling")
-	}
 	t.Setenv("HOME", "/test/home")
 	h := HTTP{URL: "https://example.com/releases/tool.tar.gz"}
 	got := h.GetHome()

--- a/internal/pkg/integration_test.go
+++ b/internal/pkg/integration_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -16,10 +15,6 @@ func init() {
 // TestCommand_GetLink_Install_Unlink tests the full symlink lifecycle:
 // create a binary in home dir → GetLink → Install (symlink) → Installed → Unlink
 func TestCommand_GetLink_Install_Unlink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlink tests not reliable on Windows CI")
-	}
-
 	// Setup: create home dir with a binary
 	homeDir := t.TempDir()
 	binDir := t.TempDir()
@@ -93,10 +88,6 @@ func TestCommand_GetLink_Install_Unlink(t *testing.T) {
 
 // TestCommand_GetLink_dotFrom tests the special case where From is "."
 func TestCommand_GetLink_dotFrom(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlink tests not reliable on Windows CI")
-	}
-
 	homeDir := t.TempDir()
 	binDir := t.TempDir()
 	t.Setenv("AFX_COMMAND_PATH", binDir)
@@ -205,10 +196,6 @@ func TestGist_Uninstall(t *testing.T) {
 
 // TestCommand_Install_overwritesExistingSymlink tests that Install replaces an existing symlink
 func TestCommand_Install_overwritesExistingSymlink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlink tests not reliable on Windows CI")
-	}
-
 	homeDir := t.TempDir()
 	binDir := t.TempDir()
 	t.Setenv("AFX_COMMAND_PATH", binDir)

--- a/internal/pkg/paths_test.go
+++ b/internal/pkg/paths_test.go
@@ -1,15 +1,10 @@
 package pkg
 
 import (
-	"runtime"
 	"testing"
 )
 
 func TestDataDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on Windows due to HOME handling")
-	}
-
 	t.Run("default", func(t *testing.T) {
 		t.Setenv("AFX_DATA_DIR", "")
 		t.Setenv("XDG_DATA_HOME", "")
@@ -39,10 +34,6 @@ func TestDataDir(t *testing.T) {
 }
 
 func TestConfigDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on Windows due to HOME handling")
-	}
-
 	t.Run("default", func(t *testing.T) {
 		t.Setenv("AFX_CONFIG_DIR", "")
 		t.Setenv("XDG_CONFIG_HOME", "")
@@ -72,10 +63,6 @@ func TestConfigDir(t *testing.T) {
 }
 
 func TestBinDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on Windows due to HOME handling")
-	}
-
 	t.Run("default", func(t *testing.T) {
 		t.Setenv("AFX_COMMAND_PATH", "")
 		t.Setenv("HOME", "/home/user")

--- a/internal/state/lock.go
+++ b/internal/state/lock.go
@@ -1,0 +1,44 @@
+package state
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileLock provides file-based locking to prevent concurrent access to state.json.
+type fileLock struct {
+	path string
+	f    *os.File
+}
+
+func newFileLock(path string) *fileLock {
+	return &fileLock{path: path + ".lock"}
+}
+
+func (l *fileLock) lock() error {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		// Cannot create lock file (e.g. non-existent directory in tests)
+		return err
+	}
+	l.f = f
+	// Use LOCK_NB (non-blocking) to avoid hanging if another process holds the lock
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		l.f = nil
+		return err
+	}
+	return nil
+}
+
+func (l *fileLock) unlock() error {
+	if l.f == nil {
+		return nil
+	}
+	if err := syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN); err != nil {
+		return err
+	}
+	l.f.Close()
+	os.Remove(l.path)
+	return nil
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -28,6 +28,7 @@ type State struct {
 	packages map[ID]Resource
 	path     string
 	mu       sync.RWMutex
+	flock    *fileLock
 
 	// No record in state file
 	Additions []Resource
@@ -227,11 +228,17 @@ func Keys(resources []Resource) []string {
 }
 
 func Open(path string, resourcers []Resourcer) (*State, error) {
+	fl := newFileLock(path)
+	if err := fl.lock(); err != nil {
+		log.Printf("[WARN] failed to acquire state lock: %v", err)
+	}
+
 	s := State{
 		Self:     Self{Resources: map[ID]Resource{}},
 		path:     path,
 		packages: map[ID]Resource{},
 		mu:       sync.RWMutex{},
+		flock:    fl,
 	}
 
 	for _, resourcer := range resourcers {
@@ -267,6 +274,14 @@ func Open(path string, resourcers []Resourcer) (*State, error) {
 	}
 
 	return &s, s.save()
+}
+
+// Close releases the file lock on the state file.
+func (s *State) Close() error {
+	if s.flock != nil {
+		return s.flock.unlock()
+	}
+	return nil
 }
 
 func (s *State) Add(resourcer Resourcer) {


### PR DESCRIPTION
## Summary
Drop Windows support since afx is a Unix CLI tool, rename `internal/pkg` to `internal/manager` for clarity, and add flock-based file locking on state.json to prevent concurrent access corruption.

## Background
afx relies on symlinks, shell sourcing, and Unix path conventions that are not applicable on Windows. Maintaining Windows code paths, CI matrix entries, and test skips added complexity without real users. The `internal/pkg` name was a workaround for Go's `package` keyword restriction and didn't convey the domain. The state file had no protection against concurrent writes from multiple terminal sessions.

## Changes

### 1. Drop Windows support
- Remove `windows` from goreleaser build targets and archive format overrides
- Remove `windows-latest` from CI test matrix
- Simplify `ExpandTilda`: remove `HomeDrive`/`HomePath` Windows branch
- Simplify `shell.Run`: remove `cmd.exe` Windows branch
- Remove all `runtime.GOOS == "windows"` test skips and unused `runtime` imports

### 2. Rename internal/pkg to internal/manager
- Rename directory and update package declaration to `manager`
- Update all import paths and `afxpkg` aliases to `manager`
- Better conveys the domain: managing package installations

### 3. Add file lock on state.json
- New `internal/state/lock.go` with flock-based file locking
- Uses `LOCK_NB` (non-blocking) to avoid hanging if lock is held
- Lock acquired in `Open()`, released in `Close()`
- Graceful degradation: warns and continues if lock cannot be acquired
- Add `.lock` and `docs/temp_*` patterns to `.gitignore`