### PR TITLE
Delegate gh extension management to gh CLI subprocess

### DIFF
--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/babarot/afx/internal/env"
+	"github.com/babarot/afx/internal/gh"
 	"github.com/babarot/afx/internal/github"
 	manager "github.com/babarot/afx/internal/manager"
 	"github.com/babarot/afx/internal/printers"
@@ -44,6 +45,7 @@ func (m *metaCmd) init() error {
 	if err := m.loadConfigs(); err != nil {
 		return err
 	}
+	m.injectGHRunner()
 	if err := m.initPackages(); err != nil {
 		return err
 	}
@@ -87,6 +89,17 @@ func (m *metaCmd) loadConfigs() error {
 	m.main = app
 	m.packages = pkgs
 	return nil
+}
+
+// injectGHRunner sets a gh.Runner on all GitHub packages that are gh extensions.
+func (m *metaCmd) injectGHRunner() {
+	runner := gh.NewRunner()
+	for _, pkg := range m.packages {
+		g, ok := pkg.(*manager.GitHub)
+		if ok && g.IsGHExtension() {
+			g.GHRunner = runner
+		}
+	}
 }
 
 // initPackages validates and sorts packages by dependency order.

--- a/internal/gh/errors.go
+++ b/internal/gh/errors.go
@@ -1,0 +1,28 @@
+package gh
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNotInstalled is returned when the gh CLI binary is not found in PATH.
+	ErrNotInstalled = errors.New("gh: command not found")
+
+	// ErrNotAuthed is returned when the gh CLI reports the user is not logged in.
+	ErrNotAuthed = errors.New("gh: not authenticated, run 'gh auth login'")
+)
+
+// ExitError is returned when the gh command exits with a non-zero status.
+type ExitError struct {
+	Cmd      string
+	ExitCode int
+	Stderr   string
+}
+
+func (e *ExitError) Error() string {
+	if e.Stderr != "" {
+		return fmt.Sprintf("gh: %s (exit %d)", e.Stderr, e.ExitCode)
+	}
+	return fmt.Sprintf("gh: exited with code %d", e.ExitCode)
+}

--- a/internal/gh/mock.go
+++ b/internal/gh/mock.go
@@ -1,0 +1,25 @@
+package gh
+
+import (
+	"context"
+	"strings"
+)
+
+// MockRunner is a test double for Runner.
+type MockRunner struct {
+	Responses map[string][]byte
+	Errors    map[string]error
+	Called    [][]string
+}
+
+func (m *MockRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	key := strings.Join(args, " ")
+	m.Called = append(m.Called, args)
+	if err, ok := m.Errors[key]; ok {
+		return nil, err
+	}
+	if resp, ok := m.Responses[key]; ok {
+		return resp, nil
+	}
+	return nil, nil
+}

--- a/internal/gh/runner.go
+++ b/internal/gh/runner.go
@@ -1,0 +1,63 @@
+package gh
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// Runner abstracts gh command execution for testability.
+type Runner interface {
+	Run(ctx context.Context, args ...string) ([]byte, error)
+}
+
+// GHRunner executes gh commands as subprocesses.
+type GHRunner struct{}
+
+// NewRunner creates a new GHRunner.
+func NewRunner() *GHRunner {
+	return &GHRunner{}
+}
+
+// Run executes a gh command with the given arguments.
+func (r *GHRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	cmdStr := "gh " + strings.Join(args, " ")
+	log.Printf("[DEBUG] exec: %s", cmdStr)
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	runErr := cmd.Run()
+
+	if runErr == nil {
+		log.Printf("[DEBUG] ok: %s (%d bytes)", cmdStr, outBuf.Len())
+		return outBuf.Bytes(), nil
+	}
+
+	if errors.Is(runErr, exec.ErrNotFound) {
+		return nil, ErrNotInstalled
+	}
+
+	stderr := strings.TrimSpace(errBuf.String())
+	exitCode := cmd.ProcessState.ExitCode()
+
+	log.Printf("[WARN] command failed: %s (exit %d): %s", cmdStr, exitCode, stderr)
+
+	if strings.Contains(stderr, "not logged in") ||
+		strings.Contains(stderr, "gh auth login") {
+		return nil, fmt.Errorf("%w: %s", ErrNotAuthed, stderr)
+	}
+
+	return nil, &ExitError{
+		Cmd:      cmdStr,
+		ExitCode: exitCode,
+		Stderr:   stderr,
+	}
+}

--- a/internal/manager/gh_extension.go
+++ b/internal/manager/gh_extension.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
-	"gopkg.in/yaml.v2"
 
-	"github.com/babarot/afx/internal/github"
+	"github.com/babarot/afx/internal/gh"
 )
 
 func ValidateGHExtension(fl validator.FieldLevel) bool {
@@ -23,115 +21,85 @@ func (c GitHub) IsGHExtension() bool {
 	return c.As != nil && c.As.GHExtension != nil && c.As.GHExtension.Name != ""
 }
 
-type ghManifest struct {
-	Owner    string `yaml:"owner"`
-	Name     string `yaml:"name"`
-	Host     string `yaml:"host"`
-	Tag      string `yaml:"tag"`
-	IsPinned bool   `yaml:"ispinned"`
-	Path     string `yaml:"path"`
-}
-
-func (gh GHExtension) GetHome() string {
-	base := filepath.Join(os.Getenv("HOME"), ".local", "share", "gh", "extensions")
-	var ext string
-	if gh.RenameTo == "" {
-		ext = filepath.Join(base, gh.Name)
-	} else {
-		ext = filepath.Join(base, gh.RenameTo)
-	}
-	return ext
-}
-
-func (gh GHExtension) GetTag() string {
-	if gh.Tag != "" {
-		return gh.Tag
+func (ext GHExtension) GetTag() string {
+	if ext.Tag != "" {
+		return ext.Tag
 	}
 	return "latest"
 }
 
-func (gh GHExtension) Install(ctx context.Context, owner, repo, tag string) error {
-	available, _ := github.HasRelease(http.DefaultClient, owner, repo, tag)
-	if available {
-		err := gh.InstallFromRelease(ctx, owner, repo, tag)
-		if err != nil {
-			return fmt.Errorf("%w: %s: failed to get gh extension", err, gh.Name)
-		}
+// GetHome returns the extension directory based on the canonical name (not rename-to).
+// This path is managed by gh CLI.
+func (ext GHExtension) GetHome() string {
+	base := filepath.Join(os.Getenv("HOME"), ".local", "share", "gh", "extensions")
+	return filepath.Join(base, ext.Name)
+}
+
+// GetAliasHome returns the symlink path when rename-to is specified.
+// Returns empty string if rename-to is not set.
+func (ext GHExtension) GetAliasHome() string {
+	if ext.RenameTo == "" {
+		return ""
+	}
+	base := filepath.Join(os.Getenv("HOME"), ".local", "share", "gh", "extensions")
+	return filepath.Join(base, ext.RenameTo)
+}
+
+// Install installs the gh extension via the gh CLI.
+func (ext GHExtension) Install(ctx context.Context, runner gh.Runner, owner, repo string) error {
+	args := []string{"extension", "install", owner + "/" + repo}
+	tag := ext.GetTag()
+	if tag != "latest" {
+		args = append(args, "--pin", tag)
 	}
 
-	ghHome := gh.GetHome()
-	// ensure to create the parent dir of each gh extension's path
-	_ = os.MkdirAll(filepath.Dir(ghHome), os.ModePerm)
-
-	// make alias
-	if gh.RenameTo != "" {
-		if err := os.Symlink(
-			filepath.Join(ghHome, gh.Name),
-			filepath.Join(ghHome, gh.RenameTo),
-		); err != nil {
-			return fmt.Errorf("%w: failed to symlink as alise", err)
-		}
+	log.Printf("[DEBUG] gh extension install: %s/%s (tag=%s)", owner, repo, tag)
+	_, err := runner.Run(ctx, args...)
+	if err != nil {
+		return fmt.Errorf("gh extension install %s/%s: %w", owner, repo, err)
 	}
+	return nil
+}
 
-	if gh.GetTag() == "latest" {
-		// in case of not making manifest yaml
+// Uninstall removes the gh extension via the gh CLI.
+func (ext GHExtension) Uninstall(ctx context.Context, runner gh.Runner) error {
+	log.Printf("[DEBUG] gh extension remove: %s", ext.Name)
+	_, err := runner.Run(ctx, "extension", "remove", ext.Name)
+	if err != nil {
+		return fmt.Errorf("gh extension remove %s: %w", ext.Name, err)
+	}
+	return nil
+}
+
+// createAliasSymlink creates a rename-to symlink for the extension.
+// It removes any existing symlink first to handle updates.
+func (ext GHExtension) createAliasSymlink() error {
+	if ext.RenameTo == "" {
 		return nil
 	}
 
-	return gh.makeManifest(owner)
-}
+	aliasHome := ext.GetAliasHome()
 
-func (gh GHExtension) InstallFromRelease(ctx context.Context, owner, repo, tag string) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	log.Printf("[DEBUG] install from release: %s/%s (%s)", owner, repo, tag)
-	release, err := github.NewRelease(
-		ctx, owner, repo, tag,
-		github.WithOverwrite(),
-		github.WithWorkdir(gh.GetHome()),
-	)
-	if err != nil {
-		return err
+	// Remove existing symlink to handle updates (avoid EEXIST)
+	if _, err := os.Lstat(aliasHome); err == nil {
+		log.Printf("[DEBUG] removing existing alias symlink: %s", aliasHome)
+		os.Remove(aliasHome)
 	}
 
-	asset, err := release.Download(ctx)
-	if err != nil {
-		return fmt.Errorf("%s: failed to download: %w", release.Name, err)
+	target := ext.GetHome()
+	log.Printf("[DEBUG] creating alias symlink: %s -> %s", aliasHome, target)
+	if err := os.Symlink(target, aliasHome); err != nil {
+		return fmt.Errorf("failed to create alias symlink %s -> %s: %w", aliasHome, target, err)
 	}
-
-	if err := release.Unarchive(asset); err != nil {
-		return fmt.Errorf("%s: failed to unarchive: %w", release.Name, err)
-	}
-
 	return nil
 }
 
-func (gh GHExtension) makeManifest(owner string) error {
-	// https://github.com/cli/cli/blob/c9a2d85793c4cef026d5bb941b3ac4121c81ae10/pkg/cmd/extension/manager.go#L424-L451
-	manifest := ghManifest{
-		Name:     gh.Name,
-		Owner:    owner,
-		Host:     "github.com",
-		Path:     gh.GetHome(),
-		Tag:      gh.GetTag(),
-		IsPinned: false,
+// removeAliasSymlink removes the rename-to symlink.
+func (ext GHExtension) removeAliasSymlink() {
+	if ext.RenameTo == "" {
+		return
 	}
-	bs, err := yaml.Marshal(manifest)
-	if err != nil {
-		return fmt.Errorf("failed to serialize manifest: %w", err)
-	}
-
-	manifestPath := filepath.Join(gh.GetHome(), "manifest.yml")
-	f, err := os.OpenFile(manifestPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to open manifest for writing: %w", err)
-	}
-	defer f.Close()
-
-	_, err = f.Write(bs)
-	if err != nil {
-		return fmt.Errorf("failed write manifest file: %w", err)
-	}
-	return nil
+	aliasHome := ext.GetAliasHome()
+	log.Printf("[DEBUG] removing alias symlink: %s", aliasHome)
+	os.Remove(aliasHome)
 }

--- a/internal/manager/github.go
+++ b/internal/manager/github.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+
+	"github.com/babarot/afx/internal/gh"
 )
 
 // GitHub represents GitHub repository
@@ -24,6 +26,8 @@ type GitHub struct {
 	As      *GitHubAs `yaml:"as"`
 
 	DependsOn []string `yaml:"depends-on"`
+
+	GHRunner gh.Runner `yaml:"-"`
 }
 
 type GitHubAs struct {

--- a/internal/manager/github_install.go
+++ b/internal/manager/github_install.go
@@ -102,6 +102,26 @@ func (c GitHub) Install(ctx context.Context, status chan<- runner.Status) error 
 		// Go installing step!
 	}
 
+	// gh extension: delegate entirely to gh CLI
+	if c.IsGHExtension() {
+		if c.GHRunner == nil {
+			err := fmt.Errorf("%s: gh runner not initialized", c.Name)
+			status <- runner.Status{Name: c.GetName(), Done: true, Err: true}
+			return err
+		}
+		ext := c.As.GHExtension
+		if err := ext.Install(ctx, c.GHRunner, c.Owner, c.Repo); err != nil {
+			err = fmt.Errorf("%s: failed to install gh extension: %w", c.Name, err)
+			status <- runner.Status{Name: c.GetName(), Done: true, Err: true}
+			return err
+		}
+		if err := ext.createAliasSymlink(); err != nil {
+			log.Printf("[WARN] %s: %v", c.Name, err)
+		}
+		status <- runner.Status{Name: c.GetName(), Done: true, Err: false}
+		return nil
+	}
+
 	switch {
 	case c.Release == nil:
 		err := c.Clone(ctx)
@@ -120,16 +140,6 @@ func (c GitHub) Install(ctx context.Context, status chan<- runner.Status) error 
 	}
 
 	var errs []error
-
-	if c.IsGHExtension() {
-		gh := c.As.GHExtension
-		err := gh.Install(ctx, c.Owner, c.Repo, gh.GetTag())
-		if err != nil {
-			err = fmt.Errorf("%s: failed to get from release: %w", c.Name, err)
-			status <- runner.Status{Name: c.GetName(), Done: true, Err: true}
-			return err
-		}
-	}
 
 	if c.HasPluginBlock() {
 		if err := c.Plugin.Install(c); err != nil {
@@ -224,6 +234,16 @@ func (c GitHub) templateFilename() string {
 }
 
 func (c GitHub) Uninstall(ctx context.Context) error {
+	// gh extension: delegate to gh CLI
+	if c.IsGHExtension() {
+		if c.GHRunner == nil {
+			return fmt.Errorf("%s: gh runner not initialized", c.Name)
+		}
+		ext := c.As.GHExtension
+		ext.removeAliasSymlink()
+		return ext.Uninstall(ctx, c.GHRunner)
+	}
+
 	var errs []error
 
 	delete := func(f string) {

--- a/internal/manager/resource.go
+++ b/internal/manager/resource.go
@@ -43,8 +43,10 @@ func getResource(pkg Package) state.Resource {
 		}
 		if pkg.IsGHExtension() {
 			ty = "GitHub (gh extension)"
-			gh := pkg.As.GHExtension
-			paths = append(paths, gh.GetHome())
+			ext := pkg.As.GHExtension
+			if alias := ext.GetAliasHome(); alias != "" {
+				paths = append(paths, alias)
+			}
 		}
 	case Gist:
 		ty = "Gist"


### PR DESCRIPTION
## Summary
Replace direct GitHub API calls and internal file manipulation for gh extension install/uninstall with `gh` CLI subprocess invocations. This eliminates coupling to gh CLI's private internal directory layout and manifest schema, relying instead on the stable public CLI interface (`gh extension install/remove`).

## Background
Previously, afx managed gh extensions by directly calling the GitHub Release API, downloading assets into `~/.local/share/gh/extensions/`, and generating `manifest.yml` files that mimic gh CLI's internal format. This approach depends on undocumented implementation details (directory layout, manifest schema) that can change without notice, silently breaking afx. Since gh extension users already have `gh` installed, delegating to the public CLI is both safer and simpler.

## Changes

### New: `internal/gh/` package
- **`runner.go`** — `Runner` interface + `GHRunner` implementation that executes `gh` as a subprocess via `exec.CommandContext`, with detection of `ErrNotInstalled` (binary not found) and `ErrNotAuthed` (not logged in)
- **`errors.go`** — Sentinel errors and `ExitError` type for non-zero exit codes
- **`mock.go`** — `MockRunner` test double for unit testing

### Rewritten: `internal/manager/gh_extension.go`
- Removed: `InstallFromRelease()`, `makeManifest()`, `ghManifest` struct, all `github.HasRelease`/`github.NewRelease` dependencies
- Added: `Install()` delegates to `gh extension install [--pin tag]`, `Uninstall()` delegates to `gh extension remove`
- `GetHome()` now returns the canonical (non-renamed) extension path; new `GetAliasHome()` returns the rename-to symlink path
- `createAliasSymlink()` removes existing symlinks before re-creating to avoid `EEXIST` on updates

### Modified: `internal/manager/github_install.go`
- `Install()`: gh extension check moved **before** clone/release to avoid double processing; nil guard on `GHRunner`
- `Uninstall()`: gh extension branch added to delegate removal to `gh extension remove`

### Modified: `cmd/meta.go`
- `injectGHRunner()` sets a `gh.Runner` on all `*GitHub` packages that are gh extensions after config loading

### Modified: `internal/manager/resource.go`
- Alias path (rename-to) tracked in resource paths for state management