### PR TITLE
Extract Base struct to eliminate duplicated package type methods

### DIFF
--- a/cmd/meta_test.go
+++ b/cmd/meta_test.go
@@ -17,8 +17,8 @@ func init() {
 func TestGetPackage_found(t *testing.T) {
 	m := metaCmd{
 		packages: []manager.Package{
-			&manager.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
-			&manager.GitHub{Name: "tool-b", Owner: "owner", Repo: "tool-b"},
+			&manager.GitHub{Base: manager.Base{Name: "tool-a"}, Owner: "owner", Repo: "tool-a"},
+			&manager.GitHub{Base: manager.Base{Name: "tool-b"}, Owner: "owner", Repo: "tool-b"},
 		},
 	}
 
@@ -36,7 +36,7 @@ func TestGetPackage_found(t *testing.T) {
 func TestGetPackage_notFound(t *testing.T) {
 	m := metaCmd{
 		packages: []manager.Package{
-			&manager.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
+			&manager.GitHub{Base: manager.Base{Name: "tool-a"}, Owner: "owner", Repo: "tool-a"},
 		},
 	}
 
@@ -51,9 +51,9 @@ func TestGetPackage_notFound(t *testing.T) {
 func TestGetPackages(t *testing.T) {
 	m := metaCmd{
 		packages: []manager.Package{
-			&manager.GitHub{Name: "tool-a", Owner: "owner", Repo: "tool-a"},
-			&manager.GitHub{Name: "tool-b", Owner: "owner", Repo: "tool-b"},
-			&manager.GitHub{Name: "tool-c", Owner: "owner", Repo: "tool-c"},
+			&manager.GitHub{Base: manager.Base{Name: "tool-a"}, Owner: "owner", Repo: "tool-a"},
+			&manager.GitHub{Base: manager.Base{Name: "tool-b"}, Owner: "owner", Repo: "tool-b"},
+			&manager.GitHub{Base: manager.Base{Name: "tool-c"}, Owner: "owner", Repo: "tool-c"},
 		},
 	}
 
@@ -82,19 +82,19 @@ func TestGetConfig_mergesAll(t *testing.T) {
 			"file1.yaml": {
 				Main: main,
 				GitHub: []*manager.GitHub{
-					{Name: "gh1", Owner: "o", Repo: "r1"},
-					{Name: "gh2", Owner: "o", Repo: "r2"},
+					{Base: manager.Base{Name: "gh1"}, Owner: "o", Repo: "r1"},
+					{Base: manager.Base{Name: "gh2"}, Owner: "o", Repo: "r2"},
 				},
 				Gist: []*manager.Gist{
-					{Name: "gist1", Owner: "o", ID: "id1"},
+					{Base: manager.Base{Name: "gist1"}, Owner: "o", ID: "id1"},
 				},
 			},
 			"file2.yaml": {
 				GitHub: []*manager.GitHub{
-					{Name: "gh3", Owner: "o", Repo: "r3"},
+					{Base: manager.Base{Name: "gh3"}, Owner: "o", Repo: "r3"},
 				},
 				Gist: []*manager.Gist{
-					{Name: "gist2", Owner: "o", ID: "id2"},
+					{Base: manager.Base{Name: "gist2"}, Owner: "o", ID: "id2"},
 				},
 			},
 		},
@@ -124,7 +124,7 @@ func TestGetConfig_noMain(t *testing.T) {
 		configs: map[string]manager.Config{
 			"file1.yaml": {
 				GitHub: []*manager.GitHub{
-					{Name: "gh1", Owner: "o", Repo: "r1"},
+					{Base: manager.Base{Name: "gh1"}, Owner: "o", Repo: "r1"},
 				},
 			},
 		},

--- a/internal/manager/base.go
+++ b/internal/manager/base.go
@@ -1,0 +1,79 @@
+package manager
+
+import (
+	"errors"
+	"os"
+)
+
+// Base contains fields common to all package types.
+type Base struct {
+	Name        string   `yaml:"name" validate:"required"`
+	Description string   `yaml:"description"`
+	Plugin      *Plugin  `yaml:"plugin"`
+	Command     *Command `yaml:"command"`
+	DependsOn   []string `yaml:"depends-on"`
+}
+
+// GetName returns the package name.
+func (b Base) GetName() string { return b.Name }
+
+// GetDependsOn returns the list of dependency names.
+func (b Base) GetDependsOn() []string { return b.DependsOn }
+
+// HasPluginBlock returns true if a plugin block is configured.
+func (b Base) HasPluginBlock() bool { return b.Plugin != nil }
+
+// HasCommandBlock returns true if a command block is configured.
+func (b Base) HasCommandBlock() bool { return b.Command != nil }
+
+// HasReleaseBlock returns false by default. GitHub overrides this.
+func (b Base) HasReleaseBlock() bool { return false }
+
+// GetPluginBlock returns the plugin configuration.
+func (b Base) GetPluginBlock() Plugin {
+	if b.Plugin != nil {
+		return *b.Plugin
+	}
+	return Plugin{}
+}
+
+// GetCommandBlock returns the command configuration.
+func (b Base) GetCommandBlock() Command {
+	if b.Command != nil {
+		return *b.Command
+	}
+	return Command{}
+}
+
+// initPackage runs the common initialization logic for plugin and command blocks.
+func initPackage(plugin *Plugin, command *Command, pkg Package) error {
+	var errs []error
+	if plugin != nil {
+		if err := plugin.Init(pkg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if command != nil {
+		if err := command.Init(pkg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// installedPackage checks whether the package is installed by examining
+// plugin sources, command symlinks, or home directory existence.
+func installedPackage(plugin *Plugin, command *Command, pkg Package) bool {
+	var list []bool
+	if plugin != nil {
+		list = append(list, plugin.Installed(pkg))
+	}
+	if command != nil {
+		list = append(list, command.Installed(pkg))
+	}
+	if plugin == nil && command == nil {
+		_, err := os.Stat(pkg.GetHome())
+		list = append(list, err == nil)
+	}
+	return allTrue(list)
+}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -207,75 +207,63 @@ func Sort(given []Package) ([]Package, error) {
 }
 
 // Validate validates if packages are not violated some rules
+// Validate validates if packages are not violated some rules
 func Validate(pkgs []Package) error {
 	m := make(map[string]bool)
 	var list []string
+	var errs []error
 
 	for _, pkg := range pkgs {
 		name := pkg.GetName()
-		_, exist := m[name]
-		if exist {
+		if m[name] {
 			list = append(list, name)
-			continue
 		}
 		m[name] = true
+
+		// GitHub-specific: command block is required when release block is present
+		if gh, ok := pkg.(*GitHub); ok {
+			if gh.Release != nil && gh.Command == nil {
+				errs = append(errs, fmt.Errorf("%s: command block is required when release block is present", name))
+			}
+		}
 	}
 
 	if len(list) > 0 {
-		return fmt.Errorf("duplicated packages: [%s]", strings.Join(list, ","))
+		errs = append(errs, fmt.Errorf("duplicated packages: [%s]", strings.Join(list, ",")))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (c Config) Get(args ...string) Config {
-	var part Config
-	for _, arg := range args {
-		for _, github := range c.GitHub {
-			if github.Name == arg {
-				part.GitHub = append(part.GitHub, github)
-			}
-		}
-		for _, gist := range c.Gist {
-			if gist.Name == arg {
-				part.Gist = append(part.Gist, gist)
-			}
-		}
-		for _, local := range c.Local {
-			if local.Name == arg {
-				part.Local = append(part.Local, local)
-			}
-		}
-		for _, http := range c.HTTP {
-			if http.Name == arg {
-				part.HTTP = append(part.HTTP, http)
-			}
-		}
-	}
-	return part
+	return c.filter(func(name, arg string) bool { return name == arg }, args...)
 }
 
 func (c Config) Contains(args ...string) Config {
+	return c.filter(func(name, arg string) bool { return strings.Contains(name, arg) }, args...)
+}
+
+func (c Config) filter(match func(name, arg string) bool, args ...string) Config {
 	var part Config
 	for _, arg := range args {
-		for _, github := range c.GitHub {
-			if strings.Contains(github.Name, arg) {
-				part.GitHub = append(part.GitHub, github)
+		for _, pkg := range c.GitHub {
+			if match(pkg.Name, arg) {
+				part.GitHub = append(part.GitHub, pkg)
 			}
 		}
-		for _, gist := range c.Gist {
-			if strings.Contains(gist.Name, arg) {
-				part.Gist = append(part.Gist, gist)
+		for _, pkg := range c.Gist {
+			if match(pkg.Name, arg) {
+				part.Gist = append(part.Gist, pkg)
 			}
 		}
-		for _, local := range c.Local {
-			if strings.Contains(local.Name, arg) {
-				part.Local = append(part.Local, local)
+		for _, pkg := range c.Local {
+			if match(pkg.Name, arg) {
+				part.Local = append(part.Local, pkg)
 			}
 		}
-		for _, http := range c.HTTP {
-			if strings.Contains(http.Name, arg) {
-				part.HTTP = append(part.HTTP, http)
+		for _, pkg := range c.HTTP {
+			if match(pkg.Name, arg) {
+				part.HTTP = append(part.HTTP, pkg)
 			}
 		}
 	}

--- a/internal/manager/config.go
+++ b/internal/manager/config.go
@@ -220,11 +220,9 @@ func Validate(pkgs []Package) error {
 		}
 		m[name] = true
 
-		// GitHub-specific: command block is required when release block is present
-		if gh, ok := pkg.(*GitHub); ok {
-			if gh.Release != nil && gh.Command == nil {
-				errs = append(errs, fmt.Errorf("%s: command block is required when release block is present", name))
-			}
+		// command block is required when release block is present
+		if pkg.HasReleaseBlock() && !pkg.HasCommandBlock() {
+			errs = append(errs, fmt.Errorf("%s: command block is required when release block is present", name))
 		}
 	}
 

--- a/internal/manager/config_test.go
+++ b/internal/manager/config_test.go
@@ -21,15 +21,15 @@ func TestValidate(t *testing.T) {
 	}{
 		"no duplicates": {
 			pkgs: []Package{
-				&GitHub{Name: "pkg1", Owner: "o", Repo: "r1"},
-				&GitHub{Name: "pkg2", Owner: "o", Repo: "r2"},
+				&GitHub{Base: Base{Name: "pkg1"}, Owner: "o", Repo: "r1"},
+				&GitHub{Base: Base{Name: "pkg2"}, Owner: "o", Repo: "r2"},
 			},
 			wantErr: false,
 		},
 		"with duplicates": {
 			pkgs: []Package{
-				&GitHub{Name: "pkg1", Owner: "o", Repo: "r1"},
-				&GitHub{Name: "pkg1", Owner: "o", Repo: "r2"},
+				&GitHub{Base: Base{Name: "pkg1"}, Owner: "o", Repo: "r1"},
+				&GitHub{Base: Base{Name: "pkg1"}, Owner: "o", Repo: "r2"},
 			},
 			wantErr: true,
 		},
@@ -39,15 +39,15 @@ func TestValidate(t *testing.T) {
 		},
 		"mixed types no duplicate": {
 			pkgs: []Package{
-				&GitHub{Name: "pkg1", Owner: "o", Repo: "r"},
-				&Local{Name: "pkg2", Directory: "/tmp"},
+				&GitHub{Base: Base{Name: "pkg1"}, Owner: "o", Repo: "r"},
+				&Local{Base: Base{Name: "pkg2"}, Directory: "/tmp"},
 			},
 			wantErr: false,
 		},
 		"mixed types with duplicate": {
 			pkgs: []Package{
-				&GitHub{Name: "same", Owner: "o", Repo: "r"},
-				&Local{Name: "same", Directory: "/tmp"},
+				&GitHub{Base: Base{Name: "same"}, Owner: "o", Repo: "r"},
+				&Local{Base: Base{Name: "same"}, Directory: "/tmp"},
 			},
 			wantErr: true,
 		},
@@ -69,11 +69,11 @@ func TestValidate(t *testing.T) {
 func TestConfig_Get(t *testing.T) {
 	cfg := Config{
 		GitHub: []*GitHub{
-			{Name: "foo", Owner: "o", Repo: "foo"},
-			{Name: "bar", Owner: "o", Repo: "bar"},
+			{Base: Base{Name: "foo"}, Owner: "o", Repo: "foo"},
+			{Base: Base{Name: "bar"}, Owner: "o", Repo: "bar"},
 		},
 		Local: []*Local{
-			{Name: "baz", Directory: "/tmp/baz"},
+			{Base: Base{Name: "baz"}, Directory: "/tmp/baz"},
 		},
 	}
 
@@ -113,11 +113,11 @@ func TestConfig_Get(t *testing.T) {
 func TestConfig_Contains(t *testing.T) {
 	cfg := Config{
 		GitHub: []*GitHub{
-			{Name: "my-tool", Owner: "o", Repo: "r1"},
-			{Name: "other-lib", Owner: "o", Repo: "r2"},
+			{Base: Base{Name: "my-tool"}, Owner: "o", Repo: "r1"},
+			{Base: Base{Name: "other-lib"}, Owner: "o", Repo: "r2"},
 		},
 		Local: []*Local{
-			{Name: "my-local", Directory: "/tmp"},
+			{Base: Base{Name: "my-local"}, Directory: "/tmp"},
 		},
 	}
 
@@ -186,14 +186,14 @@ func TestVisitYAML(t *testing.T) {
 func TestParse(t *testing.T) {
 	cfg := Config{
 		GitHub: []*GitHub{
-			{Name: "gh1", Owner: "o", Repo: "r1"},
-			{Name: "gh2", Owner: "o", Repo: "r2"},
+			{Base: Base{Name: "gh1"}, Owner: "o", Repo: "r1"},
+			{Base: Base{Name: "gh2"}, Owner: "o", Repo: "r2"},
 		},
 		Gist: []*Gist{
-			{Name: "gist1", Owner: "o", ID: "abc"},
+			{Base: Base{Name: "gist1"}, Owner: "o", ID: "abc"},
 		},
 		Local: []*Local{
-			{Name: "local1", Directory: "/tmp"},
+			{Base: Base{Name: "local1"}, Directory: "/tmp"},
 		},
 	}
 
@@ -222,28 +222,28 @@ func TestSort(t *testing.T) {
 	}{
 		"no dependencies": {
 			pkgs: []Package{
-				&GitHub{Name: "a", Owner: "o", Repo: "a"},
-				&GitHub{Name: "b", Owner: "o", Repo: "b"},
+				&GitHub{Base: Base{Name: "a"}, Owner: "o", Repo: "a"},
+				&GitHub{Base: Base{Name: "b"}, Owner: "o", Repo: "b"},
 			},
 			wantLen: 2,
 		},
 		"with dependency": {
 			pkgs: []Package{
-				&GitHub{Name: "a", Owner: "o", Repo: "a", DependsOn: []string{"b"}},
-				&GitHub{Name: "b", Owner: "o", Repo: "b"},
+				&GitHub{Base: Base{Name: "a", DependsOn: []string{"b"}}, Owner: "o", Repo: "a"},
+				&GitHub{Base: Base{Name: "b"}, Owner: "o", Repo: "b"},
 			},
 			wantLen: 2,
 		},
 		"invalid dependency": {
 			pkgs: []Package{
-				&GitHub{Name: "a", Owner: "o", Repo: "a", DependsOn: []string{"nonexistent"}},
+				&GitHub{Base: Base{Name: "a", DependsOn: []string{"nonexistent"}}, Owner: "o", Repo: "a"},
 			},
 			wantErr: true,
 		},
 		"circular dependency": {
 			pkgs: []Package{
-				&GitHub{Name: "a", Owner: "o", Repo: "a", DependsOn: []string{"b"}},
-				&GitHub{Name: "b", Owner: "o", Repo: "b", DependsOn: []string{"a"}},
+				&GitHub{Base: Base{Name: "a", DependsOn: []string{"b"}}, Owner: "o", Repo: "a"},
+				&GitHub{Base: Base{Name: "b", DependsOn: []string{"a"}}, Owner: "o", Repo: "b"},
 			},
 			wantErr: true,
 		},
@@ -271,8 +271,8 @@ func TestSort(t *testing.T) {
 func TestSort_order(t *testing.T) {
 	// b depends on a, so a must come first
 	pkgs := []Package{
-		&GitHub{Name: "b", Owner: "o", Repo: "b", DependsOn: []string{"a"}},
-		&GitHub{Name: "a", Owner: "o", Repo: "a"},
+		&GitHub{Base: Base{Name: "b", DependsOn: []string{"a"}}, Owner: "o", Repo: "b"},
+		&GitHub{Base: Base{Name: "a"}, Owner: "o", Repo: "a"},
 	}
 	sorted, err := Sort(pkgs)
 	if err != nil {
@@ -290,10 +290,10 @@ func TestSort_order(t *testing.T) {
 
 func TestConfig_Get_allTypes(t *testing.T) {
 	cfg := Config{
-		GitHub: []*GitHub{{Name: "x", Owner: "o", Repo: "r"}},
-		Gist:   []*Gist{{Name: "x", Owner: "o", ID: "id"}},
-		Local:  []*Local{{Name: "x", Directory: "/tmp"}},
-		HTTP:   []*HTTP{{Name: "x", URL: "https://example.com"}},
+		GitHub: []*GitHub{{Base: Base{Name: "x"}, Owner: "o", Repo: "r"}},
+		Gist:   []*Gist{{Base: Base{Name: "x"}, Owner: "o", ID: "id"}},
+		Local:  []*Local{{Base: Base{Name: "x"}, Directory: "/tmp"}},
+		HTTP:   []*HTTP{{Base: Base{Name: "x"}, URL: "https://example.com"}},
 	}
 
 	got := cfg.Get("x")
@@ -305,8 +305,8 @@ func TestConfig_Get_allTypes(t *testing.T) {
 
 func TestValidate_errorMessage(t *testing.T) {
 	pkgs := []Package{
-		&GitHub{Name: "dup", Owner: "o", Repo: "r1"},
-		&GitHub{Name: "dup", Owner: "o", Repo: "r2"},
+		&GitHub{Base: Base{Name: "dup"}, Owner: "o", Repo: "r1"},
+		&GitHub{Base: Base{Name: "dup"}, Owner: "o", Repo: "r2"},
 	}
 	err := Validate(pkgs)
 	if err == nil {
@@ -323,15 +323,15 @@ func TestHasGitHubReleaseBlock(t *testing.T) {
 		want bool
 	}{
 		"no release": {
-			pkgs: []Package{&GitHub{Name: "a", Owner: "o", Repo: "r"}},
+			pkgs: []Package{&GitHub{Base: Base{Name: "a"}, Owner: "o", Repo: "r"}},
 			want: false,
 		},
 		"with release": {
-			pkgs: []Package{&GitHub{Name: "a", Owner: "o", Repo: "r", Release: &GitHubRelease{}}},
+			pkgs: []Package{&GitHub{Base: Base{Name: "a"}, Owner: "o", Repo: "r", Release: &GitHubRelease{}}},
 			want: true,
 		},
 		"non-github": {
-			pkgs: []Package{&Local{Name: "a", Directory: "/tmp"}},
+			pkgs: []Package{&Local{Base: Base{Name: "a"}, Directory: "/tmp"}},
 			want: false,
 		},
 		"empty": {
@@ -356,27 +356,27 @@ func TestHasSudoInCommandBuildSteps(t *testing.T) {
 		want bool
 	}{
 		"no command block": {
-			pkgs: []Package{&GitHub{Name: "a", Owner: "o", Repo: "r"}},
+			pkgs: []Package{&GitHub{Base: Base{Name: "a"}, Owner: "o", Repo: "r"}},
 			want: false,
 		},
 		"with sudo": {
 			pkgs: []Package{&GitHub{
-				Name: "a", Owner: "o", Repo: "r",
-				Command: &Command{Build: &Build{Steps: []string{"sudo make install"}}},
+				Base:  Base{Name: "a", Command: &Command{Build: &Build{Steps: []string{"sudo make install"}}}},
+				Owner: "o", Repo: "r",
 			}},
 			want: true,
 		},
 		"without sudo": {
 			pkgs: []Package{&GitHub{
-				Name: "a", Owner: "o", Repo: "r",
-				Command: &Command{Build: &Build{Steps: []string{"make install"}}},
+				Base:  Base{Name: "a", Command: &Command{Build: &Build{Steps: []string{"make install"}}}},
+				Owner: "o", Repo: "r",
 			}},
 			want: false,
 		},
 		"no build": {
 			pkgs: []Package{&GitHub{
-				Name: "a", Owner: "o", Repo: "r",
-				Command: &Command{},
+				Base:  Base{Name: "a", Command: &Command{}},
+				Owner: "o", Repo: "r",
 			}},
 			want: false,
 		},

--- a/internal/manager/gist.go
+++ b/internal/manager/gist.go
@@ -13,37 +13,23 @@ import (
 	"github.com/babarot/afx/internal/state"
 )
 
-// Gist represents
+// Gist represents a GitHub Gist package.
 type Gist struct {
-	Name string `yaml:"name" validate:"required"`
+	Base `yaml:",inline"`
 
-	Owner       string `yaml:"owner" validate:"required"`
-	ID          string `yaml:"id" validate:"required"`
-	Description string `yaml:"description"`
-
-	Plugin  *Plugin  `yaml:"plugin"`
-	Command *Command `yaml:"command"`
-
-	DependsOn []string `yaml:"depends-on"`
+	Owner string `yaml:"owner" validate:"required"`
+	ID    string `yaml:"id" validate:"required"`
 }
 
-// Init is
-func (c Gist) Init() error {
-	var errs []error
-	if c.HasPluginBlock() {
-		if err := c.Plugin.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if c.HasCommandBlock() {
-		if err := c.Command.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
+func (c Gist) Init() error     { return initPackage(c.Plugin, c.Command, c) }
+func (c Gist) Installed() bool { return installedPackage(c.Plugin, c.Command, c) }
+
+func (c Gist) GetHome() string {
+	return filepath.Join(DataDir(), "gist.github.com", c.Owner, c.ID)
 }
 
-// Install is
+func (c Gist) GetResource() state.Resource { return getResource(c) }
+
 func (c Gist) Install(ctx context.Context, status chan<- runner.Status) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -53,7 +39,6 @@ func (c Gist) Install(ctx context.Context, status chan<- runner.Status) error {
 		log.Println("[DEBUG] canceled")
 		return nil
 	default:
-		// Go installing step!
 	}
 
 	if _, err := os.Stat(c.GetHome()); err == nil {
@@ -88,57 +73,6 @@ func (c Gist) Install(ctx context.Context, status chan<- runner.Status) error {
 	return errors.Join(errs...)
 }
 
-// Installed is
-func (c Gist) Installed() bool {
-	var list []bool
-
-	if c.HasPluginBlock() {
-		list = append(list, c.Plugin.Installed(c))
-	}
-
-	if c.HasCommandBlock() {
-		list = append(list, c.Command.Installed(c))
-	}
-
-	if !c.HasPluginBlock() && !c.HasCommandBlock() {
-		_, err := os.Stat(c.GetHome())
-		list = append(list, err == nil)
-	}
-
-	return allTrue(list)
-}
-
-// HasPluginBlock is
-func (c Gist) HasPluginBlock() bool {
-	return c.Plugin != nil
-}
-
-// HasCommandBlock is
-func (c Gist) HasCommandBlock() bool {
-	return c.Command != nil
-}
-
-func (c Gist) HasReleaseBlock() bool {
-	return false
-}
-
-// GetPluginBlock is
-func (c Gist) GetPluginBlock() Plugin {
-	if c.HasPluginBlock() {
-		return *c.Plugin
-	}
-	return Plugin{}
-}
-
-// GetCommandBlock is
-func (c Gist) GetCommandBlock() Command {
-	if c.HasCommandBlock() {
-		return *c.Command
-	}
-	return Command{}
-}
-
-// Uninstall is
 func (c Gist) Uninstall(ctx context.Context) error {
 	var errs []error
 
@@ -163,29 +97,17 @@ func (c Gist) Uninstall(ctx context.Context) error {
 	}
 
 	del(c.GetHome())
-
 	return errors.Join(errs...)
-}
-
-// GetName returns a name
-func (c Gist) GetName() string {
-	return c.Name
-}
-
-// GetHome returns a path
-func (c Gist) GetHome() string {
-	return filepath.Join(DataDir(), "gist.github.com", c.Owner, c.ID)
-}
-
-func (c Gist) GetDependsOn() []string {
-	return c.DependsOn
-}
-
-func (c Gist) GetResource() state.Resource {
-	return getResource(c)
 }
 
 func (c Gist) Check(ctx context.Context, status chan<- runner.Status) error {
 	status <- runner.Status{Name: c.GetName(), Done: true, Err: false, Message: "(gist)", NoColor: true}
 	return nil
 }
+
+// ResourceMeta implementation
+
+func (c Gist) ResourceType() string         { return "Gist" }
+func (c Gist) ResourceID() string           { return fmt.Sprintf("gist.github.com/%s/%s", c.Owner, c.ID) }
+func (c Gist) ResourceVersion() string      { return "" }
+func (c Gist) ResourceExtraPaths() []string { return nil }

--- a/internal/manager/github.go
+++ b/internal/manager/github.go
@@ -1,31 +1,24 @@
 package manager
 
 import (
-	"errors"
-	"os"
+	"fmt"
 	"path/filepath"
 
 	"github.com/babarot/afx/internal/gh"
+	"github.com/babarot/afx/internal/state"
 )
 
 // GitHub represents GitHub repository
 type GitHub struct {
-	Name string `yaml:"name" validate:"required"`
+	Base `yaml:",inline"`
 
-	Owner       string `yaml:"owner"       validate:"required"`
-	Repo        string `yaml:"repo"        validate:"required"`
-	Description string `yaml:"description"`
+	Owner  string `yaml:"owner" validate:"required"`
+	Repo   string `yaml:"repo"  validate:"required"`
+	Branch string `yaml:"branch"`
 
-	Branch string        `yaml:"branch"`
-	Option *GitHubOption `yaml:"with"`
-
+	Option  *GitHubOption  `yaml:"with"`
 	Release *GitHubRelease `yaml:"release"`
-
-	Plugin  *Plugin   `yaml:"plugin"`
-	Command *Command  `yaml:"command" validate:"required_with=Release"` // TODO: (not required Release)
-	As      *GitHubAs `yaml:"as"`
-
-	DependsOn []string `yaml:"depends-on"`
+	As      *GitHubAs      `yaml:"as"`
 
 	GHRunner gh.Runner `yaml:"-"`
 }
@@ -59,38 +52,17 @@ type GitHubReleaseAsset struct {
 
 // Init runs initialization step related to GitHub packages
 func (c GitHub) Init() error {
-	var errs []error
-	if c.HasPluginBlock() {
-		if err := c.Plugin.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if c.HasCommandBlock() {
-		if err := c.Command.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
+	return initPackage(c.Plugin, c.Command, c)
 }
 
-// Installed returns true the GitHub package is already installed
+// Installed returns true if the GitHub package is already installed
 func (c GitHub) Installed() bool {
-	var list []bool
+	return installedPackage(c.Plugin, c.Command, c)
+}
 
-	if c.HasPluginBlock() {
-		list = append(list, c.Plugin.Installed(c))
-	}
-
-	if c.HasCommandBlock() {
-		list = append(list, c.Command.Installed(c))
-	}
-
-	if !c.HasPluginBlock() && !c.HasCommandBlock() {
-		_, err := os.Stat(c.GetHome())
-		list = append(list, err == nil)
-	}
-
-	return allTrue(list)
+// HasReleaseBlock overrides Base to check the Release field.
+func (c GitHub) HasReleaseBlock() bool {
+	return c.Release != nil
 }
 
 func (c GitHub) GetReleaseTag() string {
@@ -100,38 +72,7 @@ func (c GitHub) GetReleaseTag() string {
 	return "latest"
 }
 
-func (c GitHub) HasPluginBlock() bool {
-	return c.Plugin != nil
-}
-
-func (c GitHub) HasCommandBlock() bool {
-	return c.Command != nil
-}
-
-func (c GitHub) HasReleaseBlock() bool {
-	return c.Release != nil
-}
-
-func (c GitHub) GetPluginBlock() Plugin {
-	if c.HasPluginBlock() {
-		return *c.Plugin
-	}
-	return Plugin{}
-}
-
-func (c GitHub) GetCommandBlock() Command {
-	if c.HasCommandBlock() {
-		return *c.Command
-	}
-	return Command{}
-}
-
-// GetName returns a name
-func (c GitHub) GetName() string {
-	return c.Name
-}
-
-// GetHome returns a path
+// GetHome returns the installation path for this package.
 func (c GitHub) GetHome() string {
 	if c.IsGHExtension() {
 		return c.As.GHExtension.GetHome()
@@ -139,6 +80,41 @@ func (c GitHub) GetHome() string {
 	return filepath.Join(DataDir(), "github.com", c.Owner, c.Repo)
 }
 
-func (c GitHub) GetDependsOn() []string {
-	return c.DependsOn
+func (c GitHub) GetResource() state.Resource {
+	return getResource(c)
+}
+
+// ResourceMeta implementation
+
+func (c GitHub) ResourceType() string {
+	if c.IsGHExtension() {
+		return "GitHub (gh extension)"
+	}
+	if c.HasReleaseBlock() {
+		return "GitHub Release"
+	}
+	return "GitHub"
+}
+
+func (c GitHub) ResourceID() string {
+	if c.HasReleaseBlock() {
+		return fmt.Sprintf("github.com/release/%s/%s", c.Owner, c.Repo)
+	}
+	return fmt.Sprintf("github.com/%s/%s", c.Owner, c.Repo)
+}
+
+func (c GitHub) ResourceVersion() string {
+	if c.HasReleaseBlock() {
+		return c.Release.Tag
+	}
+	return ""
+}
+
+func (c GitHub) ResourceExtraPaths() []string {
+	if c.IsGHExtension() {
+		if alias := c.As.GHExtension.GetAliasHome(); alias != "" {
+			return []string{alias}
+		}
+	}
+	return nil
 }

--- a/internal/manager/github_install.go
+++ b/internal/manager/github_install.go
@@ -12,7 +12,6 @@ import (
 	"github.com/babarot/afx/internal/git"
 	"github.com/babarot/afx/internal/github"
 	"github.com/babarot/afx/internal/runner"
-	"github.com/babarot/afx/internal/state"
 	"github.com/babarot/afx/internal/templates"
 )
 
@@ -242,8 +241,4 @@ func (c GitHub) Uninstall(ctx context.Context) error {
 
 	delete(c.GetHome())
 	return errors.Join(errs...)
-}
-
-func (c GitHub) GetResource() state.Resource {
-	return getResource(c)
 }

--- a/internal/manager/http.go
+++ b/internal/manager/http.go
@@ -20,17 +20,11 @@ import (
 	"github.com/babarot/afx/internal/templates"
 )
 
-// HTTP represents
+// HTTP represents an HTTP-downloadable package.
 type HTTP struct {
-	Name string `yaml:"name" validate:"required"`
+	Base `yaml:",inline"`
 
-	URL         string `yaml:"url" validate:"required,url"`
-	Description string `yaml:"description"`
-
-	Plugin  *Plugin  `yaml:"plugin"`
-	Command *Command `yaml:"command"`
-
-	DependsOn []string  `yaml:"depends-on"`
+	URL       string    `yaml:"url" validate:"required,url"`
 	Templates Templates `yaml:"templates"`
 }
 
@@ -38,21 +32,15 @@ type Templates struct {
 	Replacements map[string]string `yaml:"replacements"`
 }
 
-// Init is
-func (c HTTP) Init() error {
-	var errs []error
-	if c.HasPluginBlock() {
-		if err := c.Plugin.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if c.HasCommandBlock() {
-		if err := c.Command.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
+func (c HTTP) Init() error     { return initPackage(c.Plugin, c.Command, c) }
+func (c HTTP) Installed() bool { return installedPackage(c.Plugin, c.Command, c) }
+
+func (c HTTP) GetHome() string {
+	u, _ := url.Parse(c.URL)
+	return filepath.Join(DataDir(), u.Host, filepath.Dir(u.Path))
 }
+
+func (c HTTP) GetResource() state.Resource { return getResource(c) }
 
 func (c HTTP) call(ctx context.Context) error {
 	log.Printf("[TRACE] Get %s\n", c.URL)
@@ -96,14 +84,12 @@ func (c HTTP) call(ctx context.Context) error {
 	return nil
 }
 
-// Install is
 func (c HTTP) Install(ctx context.Context, status chan<- runner.Status) error {
 	select {
 	case <-ctx.Done():
 		log.Println("[DEBUG] canceled")
 		return nil
 	default:
-		// Go installing step!
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -180,57 +166,6 @@ func unarchiveV2(path string) error {
 	})
 }
 
-// Installed is
-func (c HTTP) Installed() bool {
-	var list []bool
-
-	if c.HasPluginBlock() {
-		list = append(list, c.Plugin.Installed(c))
-	}
-
-	if c.HasCommandBlock() {
-		list = append(list, c.Command.Installed(c))
-	}
-
-	if !c.HasPluginBlock() && !c.HasCommandBlock() {
-		_, err := os.Stat(c.GetHome())
-		list = append(list, err == nil)
-	}
-
-	return allTrue(list)
-}
-
-// HasPluginBlock is
-func (c HTTP) HasPluginBlock() bool {
-	return c.Plugin != nil
-}
-
-// HasCommandBlock is
-func (c HTTP) HasCommandBlock() bool {
-	return c.Command != nil
-}
-
-func (c HTTP) HasReleaseBlock() bool {
-	return false
-}
-
-// GetPluginBlock is
-func (c HTTP) GetPluginBlock() Plugin {
-	if c.HasPluginBlock() {
-		return *c.Plugin
-	}
-	return Plugin{}
-}
-
-// GetCommandBlock is
-func (c HTTP) GetCommandBlock() Command {
-	if c.HasCommandBlock() {
-		return *c.Command
-	}
-	return Command{}
-}
-
-// Uninstall is
 func (c HTTP) Uninstall(ctx context.Context) error {
 	var errs []error
 
@@ -252,27 +187,7 @@ func (c HTTP) Uninstall(ctx context.Context) error {
 	}
 
 	del(c.GetHome())
-
 	return errors.Join(errs...)
-}
-
-// GetName returns a name
-func (c HTTP) GetName() string {
-	return c.Name
-}
-
-// GetHome returns a path
-func (c HTTP) GetHome() string {
-	u, _ := url.Parse(c.URL)
-	return filepath.Join(DataDir(), u.Host, filepath.Dir(u.Path))
-}
-
-func (c HTTP) GetDependsOn() []string {
-	return c.DependsOn
-}
-
-func (c HTTP) GetResource() state.Resource {
-	return getResource(c)
 }
 
 func (c *HTTP) ParseURL() {
@@ -293,3 +208,10 @@ func (c HTTP) Check(ctx context.Context, status chan<- runner.Status) error {
 	status <- runner.Status{Name: c.GetName(), Done: true, Err: false, Message: "(http)", NoColor: true}
 	return nil
 }
+
+// ResourceMeta implementation
+
+func (c HTTP) ResourceType() string         { return "HTTP" }
+func (c HTTP) ResourceID() string           { return c.URL }
+func (c HTTP) ResourceVersion() string      { return "" }
+func (c HTTP) ResourceExtraPaths() []string { return nil }

--- a/internal/manager/installed_test.go
+++ b/internal/manager/installed_test.go
@@ -73,7 +73,7 @@ func TestHTTP_GetHome(t *testing.T) {
 
 func TestHTTP_ParseURL(t *testing.T) {
 	h := &HTTP{
-		Name: "test",
+		Base: Base{Name: "test"},
 		URL:  "https://example.com/{{ .OS }}/tool",
 	}
 	h.ParseURL()
@@ -93,7 +93,7 @@ func TestGitHub_HasPluginBlock(t *testing.T) {
 			want:   false,
 		},
 		"with plugin": {
-			github: GitHub{Plugin: &Plugin{}},
+			github: GitHub{Base: Base{Plugin: &Plugin{}}},
 			want:   true,
 		},
 	}
@@ -117,7 +117,7 @@ func TestGitHub_HasCommandBlock(t *testing.T) {
 			want:   false,
 		},
 		"with command": {
-			github: GitHub{Command: &Command{}},
+			github: GitHub{Base: Base{Command: &Command{}}},
 			want:   true,
 		},
 	}
@@ -184,7 +184,7 @@ func TestGitHub_Installed_noPluginNoCommand(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	g := GitHub{Name: "test", Owner: "owner", Repo: "repo"}
+	g := GitHub{Base: Base{Name: "test"}, Owner: "owner", Repo: "repo"}
 
 	// Home doesn't exist yet
 	if g.Installed() {
@@ -206,7 +206,7 @@ func TestGist_Installed_noPluginNoCommand(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	g := Gist{Name: "test", Owner: "owner", ID: "abc123"}
+	g := Gist{Base: Base{Name: "test"}, Owner: "owner", ID: "abc123"}
 
 	if g.Installed() {
 		t.Error("Installed() should be false when home dir doesn't exist")
@@ -226,7 +226,7 @@ func TestHTTP_Installed_noPluginNoCommand(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	h := HTTP{Name: "test", URL: "https://example.com/tool"}
+	h := HTTP{Base: Base{Name: "test"}, URL: "https://example.com/tool"}
 
 	if h.Installed() {
 		t.Error("Installed() should be false when home dir doesn't exist")
@@ -243,7 +243,7 @@ func TestHTTP_Installed_noPluginNoCommand(t *testing.T) {
 }
 
 func TestLocal_Installed(t *testing.T) {
-	l := Local{Name: "test", Directory: "/tmp"}
+	l := Local{Base: Base{Name: "test"}, Directory: "/tmp"}
 	// Local.Installed() always returns true
 	if !l.Installed() {
 		t.Error("Installed() should always be true for Local")
@@ -259,7 +259,7 @@ func TestGitHub_GetPluginBlock(t *testing.T) {
 		}
 	})
 	t.Run("with plugin returns it", func(t *testing.T) {
-		g := GitHub{Plugin: &Plugin{Sources: []string{"*.zsh"}}}
+		g := GitHub{Base: Base{Plugin: &Plugin{Sources: []string{"*.zsh"}}}}
 		p := g.GetPluginBlock()
 		if len(p.Sources) != 1 {
 			t.Errorf("expected 1 source, got %d", len(p.Sources))
@@ -276,7 +276,7 @@ func TestGitHub_GetCommandBlock(t *testing.T) {
 		}
 	})
 	t.Run("with command returns it", func(t *testing.T) {
-		g := GitHub{Command: &Command{Link: []*Link{{From: "bin"}}}}
+		g := GitHub{Base: Base{Command: &Command{Link: []*Link{{From: "bin"}}}}}
 		c := g.GetCommandBlock()
 		if len(c.Link) != 1 {
 			t.Errorf("expected 1 link, got %d", len(c.Link))

--- a/internal/manager/integration_test.go
+++ b/internal/manager/integration_test.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 // TestCommand_GetLink_Install_Unlink tests the full symlink lifecycle:
-// create a binary in home dir → GetLink → Install (symlink) → Installed → Unlink
+// create a binary in home dir -> GetLink -> Install (symlink) -> Installed -> Unlink
 func TestCommand_GetLink_Install_Unlink(t *testing.T) {
 	// Setup: create home dir with a binary
 	homeDir := t.TempDir()
@@ -26,11 +26,11 @@ func TestCommand_GetLink_Install_Unlink(t *testing.T) {
 	}
 
 	pkg := &Local{
-		Name:      "test-local",
-		Directory: homeDir,
-		Command: &Command{
-			Link: []*Link{{From: "mytool"}},
+		Base: Base{
+			Name:    "test-local",
+			Command: &Command{Link: []*Link{{From: "mytool"}}},
 		},
+		Directory: homeDir,
 	}
 
 	// Test GetLink
@@ -93,11 +93,11 @@ func TestCommand_GetLink_dotFrom(t *testing.T) {
 	t.Setenv("AFX_COMMAND_PATH", binDir)
 
 	pkg := &Local{
-		Name:      "test-dot",
-		Directory: homeDir,
-		Command: &Command{
-			Link: []*Link{{From: "."}},
+		Base: Base{
+			Name:    "test-dot",
+			Command: &Command{Link: []*Link{{From: "."}}},
 		},
+		Directory: homeDir,
 	}
 
 	links, err := pkg.Command.GetLink(pkg)
@@ -116,11 +116,11 @@ func TestCommand_GetLink_dotFrom(t *testing.T) {
 // TestCommand_GetLink_homeNotExist tests error when home dir doesn't exist
 func TestCommand_GetLink_homeNotExist(t *testing.T) {
 	pkg := &Local{
-		Name:      "test-nodir",
-		Directory: "/nonexistent/path",
-		Command: &Command{
-			Link: []*Link{{From: "tool"}},
+		Base: Base{
+			Name:    "test-nodir",
+			Command: &Command{Link: []*Link{{From: "tool"}}},
 		},
+		Directory: "/nonexistent/path",
 	}
 
 	_, err := pkg.Command.GetLink(pkg)
@@ -134,11 +134,11 @@ func TestCommand_GetLink_noMatches(t *testing.T) {
 	homeDir := t.TempDir()
 
 	pkg := &Local{
-		Name:      "test-nomatch",
-		Directory: homeDir,
-		Command: &Command{
-			Link: []*Link{{From: "nonexistent_binary"}},
+		Base: Base{
+			Name:    "test-nomatch",
+			Command: &Command{Link: []*Link{{From: "nonexistent_binary"}}},
 		},
+		Directory: homeDir,
 	}
 
 	_, err := pkg.Command.GetLink(pkg)
@@ -152,7 +152,7 @@ func TestGitHub_Uninstall(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	g := GitHub{Name: "test-uninstall", Owner: "owner", Repo: "repo"}
+	g := GitHub{Base: Base{Name: "test-uninstall"}, Owner: "owner", Repo: "repo"}
 	home := g.GetHome()
 
 	// Create home dir
@@ -178,7 +178,7 @@ func TestGist_Uninstall(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	g := Gist{Name: "test-uninstall", Owner: "owner", ID: "abc123"}
+	g := Gist{Base: Base{Name: "test-uninstall"}, Owner: "owner", ID: "abc123"}
 	home := g.GetHome()
 
 	if err := os.MkdirAll(home, 0755); err != nil {
@@ -218,11 +218,11 @@ func TestCommand_Install_overwritesExistingSymlink(t *testing.T) {
 	}
 
 	pkg := &Local{
-		Name:      "test-overwrite",
-		Directory: homeDir,
-		Command: &Command{
-			Link: []*Link{{From: "tool"}},
+		Base: Base{
+			Name:    "test-overwrite",
+			Command: &Command{Link: []*Link{{From: "tool"}}},
 		},
+		Directory: homeDir,
 	}
 
 	// Install should overwrite the existing symlink

--- a/internal/manager/local.go
+++ b/internal/manager/local.go
@@ -2,7 +2,7 @@ package manager
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"os"
 
 	pathutil "github.com/babarot/afx/internal/helpers/path"
@@ -10,99 +10,40 @@ import (
 	"github.com/babarot/afx/internal/state"
 )
 
-// Local represents
+// Local represents a local directory package.
 type Local struct {
-	Name string `yaml:"name" validate:"required"`
+	Base `yaml:",inline"`
 
-	Directory   string `yaml:"directory" validate:"required"`
-	Description string `yaml:"description"`
-
-	Plugin  *Plugin  `yaml:"plugin"`
-	Command *Command `yaml:"command"`
-
-	DependsOn []string `yaml:"depends-on"`
+	Directory string `yaml:"directory" validate:"required"`
 }
 
-// Init is
-func (c Local) Init() error {
-	var errs []error
-	if c.HasPluginBlock() {
-		if err := c.Plugin.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if c.HasCommandBlock() {
-		if err := c.Command.Init(c); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
-}
+func (c Local) Init() error { return initPackage(c.Plugin, c.Command, c) }
 
-// Install is
-func (c Local) Install(ctx context.Context, status chan<- runner.Status) error {
-	return nil
-}
+// Installed always returns true for local packages.
+func (c Local) Installed() bool { return true }
 
-// Installed is
-func (c Local) Installed() bool {
-	return true
-}
-
-// HasPluginBlock is
-func (c Local) HasPluginBlock() bool {
-	return c.Plugin != nil
-}
-
-// HasCommandBlock is
-func (c Local) HasCommandBlock() bool {
-	return c.Command != nil
-}
-
-func (c Local) HasReleaseBlock() bool {
-	return false
-}
-
-// GetPluginBlock is
-func (c Local) GetPluginBlock() Plugin {
-	if c.HasPluginBlock() {
-		return *c.Plugin
-	}
-	return Plugin{}
-}
-
-// GetCommandBlock is
-func (c Local) GetCommandBlock() Command {
-	if c.HasCommandBlock() {
-		return *c.Command
-	}
-	return Command{}
-}
-
-// Uninstall is
-func (c Local) Uninstall(ctx context.Context) error {
-	return nil
-}
-
-// GetName returns a name
-func (c Local) GetName() string {
-	return c.Name
-}
-
-// GetHome returns a path
 func (c Local) GetHome() string {
 	return pathutil.ExpandTilda(os.ExpandEnv(c.Directory))
 }
 
-func (c Local) GetDependsOn() []string {
-	return c.DependsOn
+func (c Local) GetResource() state.Resource { return getResource(c) }
+
+func (c Local) Install(ctx context.Context, status chan<- runner.Status) error {
+	return nil
 }
 
-func (c Local) GetResource() state.Resource {
-	return getResource(c)
+func (c Local) Uninstall(ctx context.Context) error {
+	return nil
 }
 
 func (c Local) Check(ctx context.Context, status chan<- runner.Status) error {
 	status <- runner.Status{Name: c.GetName(), Done: true, Err: false, Message: "(local)", NoColor: true}
 	return nil
 }
+
+// ResourceMeta implementation
+
+func (c Local) ResourceType() string         { return "Local" }
+func (c Local) ResourceID() string           { return fmt.Sprintf("local/%s", c.Directory) }
+func (c Local) ResourceVersion() string      { return "" }
+func (c Local) ResourceExtraPaths() []string { return nil }

--- a/internal/manager/resource.go
+++ b/internal/manager/resource.go
@@ -1,10 +1,17 @@
 package manager
 
 import (
-	"fmt"
-
 	"github.com/babarot/afx/internal/state"
 )
+
+// ResourceMeta provides type-specific metadata for resource tracking.
+// All concrete package types implement this interface.
+type ResourceMeta interface {
+	ResourceType() string
+	ResourceID() string
+	ResourceVersion() string
+	ResourceExtraPaths() []string
+}
 
 func getResource(pkg Package) state.Resource {
 	var paths []string
@@ -26,47 +33,24 @@ func getResource(pkg Package) state.Resource {
 		}
 	}
 
-	var ty string
-	var version string
-	var id string
-
-	switch pkg := pkg.(type) {
-	case GitHub:
-		ty = "GitHub"
-		if pkg.HasReleaseBlock() {
-			ty = "GitHub Release"
-			version = pkg.Release.Tag
+	meta, ok := pkg.(ResourceMeta)
+	if !ok {
+		return state.Resource{
+			Name:  pkg.GetName(),
+			Home:  pkg.GetHome(),
+			Type:  "Unknown",
+			Paths: paths,
 		}
-		id = fmt.Sprintf("github.com/%s/%s", pkg.Owner, pkg.Repo)
-		if pkg.HasReleaseBlock() {
-			id = fmt.Sprintf("github.com/release/%s/%s", pkg.Owner, pkg.Repo)
-		}
-		if pkg.IsGHExtension() {
-			ty = "GitHub (gh extension)"
-			ext := pkg.As.GHExtension
-			if alias := ext.GetAliasHome(); alias != "" {
-				paths = append(paths, alias)
-			}
-		}
-	case Gist:
-		ty = "Gist"
-		id = fmt.Sprintf("gist.github.com/%s/%s", pkg.Owner, pkg.ID)
-	case Local:
-		ty = "Local"
-		id = fmt.Sprintf("local/%s", pkg.Directory)
-	case HTTP:
-		ty = "HTTP"
-		id = pkg.URL
-	default:
-		ty = "Unknown"
 	}
 
+	paths = append(paths, meta.ResourceExtraPaths()...)
+
 	return state.Resource{
-		ID:      id,
+		ID:      meta.ResourceID(),
 		Name:    pkg.GetName(),
 		Home:    pkg.GetHome(),
-		Type:    ty,
-		Version: version,
+		Type:    meta.ResourceType(),
+		Version: meta.ResourceVersion(),
 		Paths:   paths,
 	}
 }

--- a/internal/manager/resource_test.go
+++ b/internal/manager/resource_test.go
@@ -14,14 +14,14 @@ func TestGetResource(t *testing.T) {
 		wantName string
 	}{
 		"GitHub basic": {
-			pkg:      GitHub{Name: "test", Owner: "owner", Repo: "repo"},
+			pkg:      GitHub{Base: Base{Name: "test"}, Owner: "owner", Repo: "repo"},
 			wantType: "GitHub",
 			wantID:   "github.com/owner/repo",
 			wantName: "test",
 		},
 		"GitHub with Release": {
 			pkg: GitHub{
-				Name:    "test",
+				Base:    Base{Name: "test"},
 				Owner:   "o",
 				Repo:    "r",
 				Release: &GitHubRelease{Name: "r", Tag: "v1.0"},
@@ -32,7 +32,7 @@ func TestGetResource(t *testing.T) {
 		},
 		"GitHub GH Extension": {
 			pkg: GitHub{
-				Name:  "test",
+				Base:  Base{Name: "test"},
 				Owner: "o",
 				Repo:  "r",
 				As: &GitHubAs{
@@ -44,19 +44,19 @@ func TestGetResource(t *testing.T) {
 			wantName: "test",
 		},
 		"Gist": {
-			pkg:      Gist{Name: "test", Owner: "owner", ID: "abc123"},
+			pkg:      Gist{Base: Base{Name: "test"}, Owner: "owner", ID: "abc123"},
 			wantType: "Gist",
 			wantID:   "gist.github.com/owner/abc123",
 			wantName: "test",
 		},
 		"Local": {
-			pkg:      Local{Name: "test", Directory: "/tmp/test"},
+			pkg:      Local{Base: Base{Name: "test"}, Directory: "/tmp/test"},
 			wantType: "Local",
 			wantID:   "local//tmp/test",
 			wantName: "test",
 		},
 		"HTTP": {
-			pkg:      HTTP{Name: "test", URL: "https://example.com/tool"},
+			pkg:      HTTP{Base: Base{Name: "test"}, URL: "https://example.com/tool"},
 			wantType: "HTTP",
 			wantID:   "https://example.com/tool",
 			wantName: "test",
@@ -90,7 +90,7 @@ func TestGetResource_GitHubReleaseVersion(t *testing.T) {
 	t.Setenv("HOME", "/test/home")
 
 	pkg := GitHub{
-		Name:    "test",
+		Base:    Base{Name: "test"},
 		Owner:   "o",
 		Repo:    "r",
 		Release: &GitHubRelease{Name: "r", Tag: "v1.0"},
@@ -104,7 +104,7 @@ func TestGetResource_GitHubReleaseVersion(t *testing.T) {
 func TestGetResource_GitHubBasicNoVersion(t *testing.T) {
 	t.Setenv("HOME", "/test/home")
 
-	pkg := GitHub{Name: "test", Owner: "owner", Repo: "repo"}
+	pkg := GitHub{Base: Base{Name: "test"}, Owner: "owner", Repo: "repo"}
 	got := getResource(pkg)
 	if got.Version != "" {
 		t.Errorf("Version = %q, want empty string for non-release GitHub package", got.Version)


### PR DESCRIPTION
## Summary
Consolidate 9 copy-pasted methods across 4 package types (GitHub, Gist, HTTP, Local) into a single `Base` struct using Go embedding. Also replace the `getResource()` type switch with a `ResourceMeta` interface, and simplify `Config.Get()`/`Contains()` via a shared `filter()` helper. Net result: **-193 lines** of production code.

## Background
GitHub, Gist, HTTP, and Local types had identical implementations for 9 methods (`Init`, `Installed`, `HasPluginBlock`, `HasCommandBlock`, `GetPluginBlock`, `GetCommandBlock`, `GetName`, `GetDependsOn`, `HasReleaseBlock`). This duplication made bug fixes error-prone — a fix in one type could easily be missed in others. Additionally, `getResource()` used a type switch that defeated the purpose of the `Package` interface, and `Config.Get()`/`Contains()` duplicated the same 4-slice iteration pattern.

## Changes

### New: `internal/manager/base.go`
- `Base` struct with common fields: `Name`, `Description`, `Plugin`, `Command`, `DependsOn`
- 7 methods promoted via embedding: `GetName`, `GetDependsOn`, `HasPluginBlock`, `HasCommandBlock`, `HasReleaseBlock` (default `false`), `GetPluginBlock`, `GetCommandBlock`
- Helper functions `initPackage()` and `installedPackage()` for methods that need `GetHome()` access (Go embedding limitation — no virtual dispatch)

### Changed: Package type structs
Each type now embeds `Base` with `yaml:",inline"` and removes duplicated fields/methods:
- **GitHub**: Overrides `HasReleaseBlock()` (checks `Release != nil`). Adds `ResourceMeta` methods.
- **Gist, HTTP, Local**: Remove all 7+ duplicated methods. Add `ResourceMeta` methods.
- **Local**: Keeps `Installed() { return true }` override.

### Changed: `resource.go`
- New `ResourceMeta` interface (`ResourceType`, `ResourceID`, `ResourceVersion`, `ResourceExtraPaths`)
- `getResource()` rewritten to use interface instead of type switch

### Changed: `config.go`
- `Get()` and `Contains()` now delegate to a shared `filter()` helper
- `Validate()` now includes GitHub-specific check: `Release != nil && Command == nil` → error (previously enforced by struct tag `validate:"required_with=Release"` which cannot work across embedded structs)

### Changed: Test files (5 files)
- Struct literals updated from `GitHub{Name: "x"}` to `GitHub{Base: Base{Name: "x"}}` — mechanical change, no logic change